### PR TITLE
fix(settings): thumbnail_interval on servers not being updated on settings update

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -116,7 +116,7 @@ GPU settings are configured per-GPU in **Settings** → **Processing Options**. 
 |---------|--------|---------|-------------|
 | `cpu_threads` | Yes | `1` | Number of CPU worker threads (0–32) |
 | `thumbnail_quality` | Yes | `4` | Preview quality 1-10 (2=highest) |
-| `thumbnail_interval` | Yes | `5` | Interval between preview images (1–60 s) |
+| `thumbnail_interval` | Yes | `10` | Interval between preview images (1–60 s). Matches Plex/BIF community convention (see sidecar `-{width}-10.bif` files). |
 | `selected_libraries` | Yes | All | Library IDs to process |
 | `sort_by` (per-run) | Yes | `newest` | Order items are processed: `newest`, `oldest`, `random`, or empty for Plex's natural order. Set per manual run (New Job modal) or per schedule — not a global setting. |
 
@@ -450,7 +450,7 @@ Get current settings.
     {"device": "/dev/dri/renderD128", "name": "Intel UHD 630", "type": "intel", "enabled": true, "workers": 4, "ffmpeg_threads": 2}
   ],
   "cpu_threads": 2,
-  "thumbnail_interval": 5,
+  "thumbnail_interval": 10,
   "thumbnail_quality": 4
 }
 ```
@@ -465,7 +465,7 @@ Update settings. Send only the fields to change.
 {
   "gpu_config": [{"device": "/dev/dri/renderD128", "enabled": true, "workers": 4, "ffmpeg_threads": 2}],
   "cpu_threads": 2,
-  "thumbnail_interval": 5,
+  "thumbnail_interval": 10,
   "plex_url": "http://192.168.1.100:32400"
 }
 ```

--- a/media_preview_generator/config/__init__.py
+++ b/media_preview_generator/config/__init__.py
@@ -225,6 +225,43 @@ class Config:
         self.plex_bif_frame_interval = int(value)
 
 
+def resolve_frame_interval(server_output: dict | None) -> int:
+    """Resolve a server entry's effective BIF frame interval, in seconds.
+
+    Lookup order (each layer heals a drift introduced by a different code path):
+
+      1. ``server_output["frame_interval"]`` -- the per-server override. Post-#240
+         this matches the global; pre-#240 entries may carry a stale value, and
+         entries created before the field existed (the Jellyfin/Emby drift the
+         user's own settings exhibits today) have it missing entirely.
+      2. The global ``thumbnail_interval`` setting -- the value the user actually
+         chose in the UI. This is what FFmpeg's fps argument is derived from, so
+         honouring it here is what keeps the BIF multiplier consistent with the
+         extraction cadence.
+      3. The documented ``10`` second default -- matches the BIF/Plex community
+         convention (every sidecar in the repo's own user library is ``-320-10``)
+         and the Roku spec example.
+
+    The settings-manager singleton is imported lazily to avoid a circular
+    dependency: ``servers/plex.py`` and ``processing/multi_server.py`` must
+    not import ``web/`` at module load. The pattern matches existing usage
+    in ``processing/frame_cache.py`` and ``jobs/orchestrator.py``.
+    """
+    if isinstance(server_output, dict):
+        val = server_output.get("frame_interval")
+        if isinstance(val, int) and val > 0:
+            return val
+    try:
+        from ..web.settings_manager import get_settings_manager
+
+        val = get_settings_manager().get("thumbnail_interval")
+        if isinstance(val, int) and val > 0:
+            return val
+    except Exception:
+        pass
+    return 10
+
+
 def show_docker_help():
     """Show help message pointing users to the web UI for configuration."""
     logger.info("🐳 Docker Environment Detected")
@@ -506,12 +543,12 @@ def load_config(*, log_validation_errors: bool = True) -> Config:
     if _interval_setting in (None, ""):
         _interval_setting = ui_settings.get("plex_bif_frame_interval")
     if _interval_setting in (None, ""):
-        plex_bif_frame_interval = get_value("__never_set__", "PLEX_BIF_FRAME_INTERVAL", 5, int)
+        plex_bif_frame_interval = get_value("__never_set__", "PLEX_BIF_FRAME_INTERVAL", 10, int)
     else:
         try:
             plex_bif_frame_interval = int(_interval_setting)
         except (TypeError, ValueError):
-            plex_bif_frame_interval = get_value("__never_set__", "PLEX_BIF_FRAME_INTERVAL", 5, int)
+            plex_bif_frame_interval = get_value("__never_set__", "PLEX_BIF_FRAME_INTERVAL", 10, int)
     thumbnail_quality = get_value("thumbnail_quality", "THUMBNAIL_QUALITY", 4, int)
     tonemap_algorithm = get_value("tonemap_algorithm", "TONEMAP_ALGORITHM", "hable", str).strip().lower()
     regenerate_thumbnails = get_value("regenerate_thumbnails", "REGENERATE_THUMBNAILS", False, bool)

--- a/media_preview_generator/processing/multi_server.py
+++ b/media_preview_generator/processing/multi_server.py
@@ -39,6 +39,7 @@ import requests
 from loguru import logger
 
 from ..bif_reader import unpack_bif_to_jpegs
+from ..config import resolve_frame_interval
 from ..output import BifBundle, EmbyBifAdapter, JellyfinTrickplayAdapter, PlexBundleAdapter
 from ..output.base import OutputAdapter
 from ..output.journal import clear_meta, outputs_fresh_for_source, write_meta
@@ -149,7 +150,7 @@ def _adapter_for_server(server_config: ServerConfig) -> OutputAdapter | None:
     output = server_config.output or {}
     adapter_name = str(output.get("adapter") or "").strip().lower()
     width = int(output.get("width") or 320)
-    frame_interval = int(output.get("frame_interval") or 10)
+    frame_interval = resolve_frame_interval(output)
 
     # Default per server type when adapter name is missing.
     if not adapter_name:

--- a/media_preview_generator/servers/jellyfin.py
+++ b/media_preview_generator/servers/jellyfin.py
@@ -28,6 +28,7 @@ from typing import Any
 import requests
 from loguru import logger
 
+from ..config import resolve_frame_interval
 from ._embyish import EmbyApiClient, is_video_library_folder
 from .base import FlagTarget, HealthCheckIssue, ServerType, WebhookEvent
 
@@ -175,7 +176,7 @@ class JellyfinServer(EmbyApiClient):
         # ``frame_interval`` is in seconds. Convert here so the two
         # views agree: tiles named "<width> - 10x10/<index>.jpg"
         # match the row registered with the matching intervalMs.
-        adapter_interval_ms = int(output.get("frame_interval") or 10) * 1000
+        adapter_interval_ms = resolve_frame_interval(output) * 1000
         try:
             resp = self._request(
                 "POST",
@@ -1217,7 +1218,7 @@ class JellyfinServer(EmbyApiClient):
             "width": int(output.get("width") or 320),
             "tile_w": 10,
             "tile_h": 10,
-            "interval_ms": int(output.get("frame_interval") or 10) * 1000,
+            "interval_ms": resolve_frame_interval(output) * 1000,
         }
 
     def fetch_trickplay_options(self) -> dict[str, Any] | None:

--- a/media_preview_generator/servers/plex.py
+++ b/media_preview_generator/servers/plex.py
@@ -19,6 +19,7 @@ import requests
 import urllib3
 from loguru import logger
 
+from ..config import resolve_frame_interval
 from .base import (
     ConnectionResult,
     FlagTarget,
@@ -97,7 +98,7 @@ def _synthesize_legacy_config(cfg: ServerConfig) -> SimpleNamespace:
         plex_library_ids=enabled_lib_ids,
         plex_libraries=[],  # legacy name-based selector — superseded by ids
         plex_config_folder=(cfg.output or {}).get("plex_config_folder", "/plex"),
-        plex_bif_frame_interval=int((cfg.output or {}).get("frame_interval") or 10),
+        plex_bif_frame_interval=resolve_frame_interval(cfg.output),
     )
 
 

--- a/media_preview_generator/upgrade.py
+++ b/media_preview_generator/upgrade.py
@@ -21,7 +21,7 @@ from loguru import logger
 # -------------------------------------------------------------------------
 # Schema version — bump when adding new migrations
 # -------------------------------------------------------------------------
-_CURRENT_SCHEMA_VERSION = 12
+_CURRENT_SCHEMA_VERSION = 13
 
 
 # -------------------------------------------------------------------------
@@ -57,6 +57,14 @@ _USER_FACING_NOTES: dict[int, str] = {
         "routing matches on Plex's own machine identifier, not on the renamed id. "
         "If you'd like the URL on plex.tv to use the new cleaner form, open "
         "Servers → Plex → Webhook & Scanner and click Re-register. Optional, not required."
+    ),
+    13: (
+        "Your Thumbnail Interval setting now applies to every server consistently. "
+        "Previously a server entry either kept a stale per-server copy of the "
+        "interval (typically Plex, after a later UI change) or had none at all "
+        "(typically Jellyfin/Emby added before the field existed), which made "
+        "BIF previews drift out of sync with playback. Existing previews "
+        "regenerate normally next time the job runs."
     ),
 }
 
@@ -282,6 +290,13 @@ def _migrate_schema(sm) -> None:
         v11 -- Seeds the ``frame_reuse`` block (enabled, ttl_minutes,
                max_cache_disk_mb) so cross-server webhook reuse is on
                by default. Tunable under Settings → Performance.
+        v13 -- Aligns per-server ``output.frame_interval`` with the global
+               ``thumbnail_interval`` for upgraders whose Jellyfin/Emby
+               entries pre-date the field or whose Plex entry drifted from
+               a later UI change. PR #240 keeps them aligned going forward
+               via a post-save hook; this one-shot heals already-affected
+               installs without requiring the user to re-save settings.
+               Issue #238.
     """
     current = sm.get("_schema_version", 1)
     if current > _CURRENT_SCHEMA_VERSION:
@@ -334,6 +349,8 @@ def _migrate_schema(sm) -> None:
         _run(11, _migrate_to_v11)
     if current < 12:
         _run(12, _migrate_to_v12)
+    if current < 13:
+        _run(13, _migrate_to_v13)
 
     sm.set("_schema_version", _CURRENT_SCHEMA_VERSION)
 
@@ -1126,6 +1143,56 @@ def _migrate_to_v12(sm) -> list:
 
     detail = "; ".join(runtime_notes) if runtime_notes else "no runtime references to rewrite"
     return [f"v12: renamed legacy 'plex-default' → {new_id} ({detail})"]
+
+
+def _migrate_to_v13(sm) -> list:
+    """Align per-server ``output.frame_interval`` with the global ``thumbnail_interval``.
+
+    Pre-fix builds initialised ``media_servers[i].output.frame_interval`` at
+    server-create time and never updated it when the user later changed the
+    global ``thumbnail_interval``. Additionally, Jellyfin/Emby entries added
+    before this fix often had ``output.frame_interval`` missing entirely; the
+    six read sites then fell back to a hardcoded ``10`` regardless of the
+    user's chosen value, producing BIF previews whose declared multiplier
+    disagreed with the FFmpeg extraction cadence (issue #238).
+
+    This migration walks every server, writes ``output.frame_interval`` to
+    match the current global, and reports how many entries it touched. PR
+    #240's post-save propagation keeps the values aligned going forward; this
+    one-shot heals everyone who upgraded with stale or missing values without
+    requiring them to re-save settings.
+
+    Idempotent — a re-run with already-aligned entries is a no-op (no notes).
+    """
+    global_interval = sm.get("thumbnail_interval") or sm.get("plex_bif_frame_interval")
+    if not isinstance(global_interval, int) or global_interval <= 0:
+        # No global to align to (very-old install with neither key set); leave
+        # entries as-is so the read-side fallback to the documented default
+        # picks up.
+        return []
+
+    media_servers = sm.get("media_servers") or []
+    if not isinstance(media_servers, list):
+        return []
+
+    updated: list = []
+    drift_count = 0
+    for entry in media_servers:
+        if isinstance(entry, dict):
+            output = dict(entry.get("output") or {})
+            if output.get("frame_interval") != global_interval:
+                output["frame_interval"] = global_interval
+                entry = {**entry, "output": output}
+                drift_count += 1
+        updated.append(entry)
+
+    if drift_count:
+        sm.update({"media_servers": updated})
+        return [
+            f"v13: aligned {drift_count} server(s) output.frame_interval to "
+            f"global thumbnail_interval={global_interval} (#238)"
+        ]
+    return []
 
 
 # =========================================================================

--- a/media_preview_generator/web/routes/api_bif.py
+++ b/media_preview_generator/web/routes/api_bif.py
@@ -9,6 +9,7 @@ import urllib3
 from flask import Response, jsonify, request
 from loguru import logger
 
+from ...config import resolve_frame_interval
 from ..auth import api_token_required
 from . import api
 from ._helpers import limiter
@@ -844,7 +845,7 @@ def _resolve_previews_for_item(item, server_cfg) -> list[dict]:
 
     output_cfg = server_cfg.output or {}
     width = int(output_cfg.get("width") or 320)
-    interval = int(output_cfg.get("frame_interval") or 10)
+    interval = resolve_frame_interval(output_cfg)
 
     # Episode-vs-movie classification: the MediaItem dataclass has no
     # explicit ``kind`` field, so fall back to a title-shape check. Match on

--- a/media_preview_generator/web/routes/api_servers.py
+++ b/media_preview_generator/web/routes/api_servers.py
@@ -17,6 +17,7 @@ from typing import Any
 from flask import jsonify, request
 from loguru import logger
 
+from ...config import resolve_frame_interval
 from ...servers import (
     ServerRegistry,
     ServerType,
@@ -273,6 +274,22 @@ def _validate_server_payload(
     path_mappings = data.get("path_mappings") if "path_mappings" in data else base.get("path_mappings", [])
     exclude_paths = data.get("exclude_paths") if "exclude_paths" in data else base.get("exclude_paths", [])
     output = data.get("output") if "output" in data else base.get("output", {})
+
+    # When a client (or scripted deploy) creates / updates a server without
+    # specifying ``output.frame_interval``, default it to the user's current
+    # global ``thumbnail_interval`` rather than letting the read-side fallback
+    # silently fill in the documented 10s default. This mirrors PR #240's
+    # design — global is the source of truth — and stops Jellyfin/Emby entries
+    # from being born with ``frame_interval`` missing, which is the
+    # configuration that produced the user-visible drift in #238.
+    if isinstance(output, dict) and "frame_interval" not in output:
+        try:
+            global_interval = get_settings_manager().get("thumbnail_interval")
+            if isinstance(global_interval, int) and global_interval > 0:
+                output = dict(output)
+                output["frame_interval"] = global_interval
+        except Exception:
+            pass
     # health_dismissals is managed by the per-row dismiss endpoint
     # (POST /previews-readiness/(dis|un)dismiss). The modal Save form
     # never sends it, so this MUST carry-forward from ``base`` or every
@@ -1636,7 +1653,7 @@ def get_output_status(server_id: str):
         canonical_path=canonical_path,
         frame_dir=_Path("."),  # unused — only canonical_path is read
         bif_path=None,
-        frame_interval=int((cfg.output or {}).get("frame_interval") or 10),
+        frame_interval=resolve_frame_interval(cfg.output),
         width=int((cfg.output or {}).get("width") or 320),
         height=180,
         frame_count=0,

--- a/media_preview_generator/web/routes/api_settings.py
+++ b/media_preview_generator/web/routes/api_settings.py
@@ -543,6 +543,10 @@ def _apply_post_save_hooks(settings, updates: dict, incoming_field_keys: set[str
        new token (otherwise it keeps posting with the stale token).
     5. **Logging reconfiguration** — if any log_* field changed, rebuild
        the loguru handlers with the new level/rotation/retention.
+    6. **Thumbnail interval propagation** — if ``thumbnail_interval`` changed,
+       update ``frame_interval`` in every server's ``output`` config so the
+       BIF writer, Jellyfin trickplay registration, Emby sidecar naming, and
+       BIF viewer all use the new value immediately.
 
     Returns ``thread_warning`` (empty string when worker counts are healthy)
     so the route can include it in the JSON response.
@@ -584,6 +588,30 @@ def _apply_post_save_hooks(settings, updates: dict, incoming_field_keys: set[str
             rotation=settings.get("log_rotation_size", "10 MB"),
             retention=settings.get("log_retention_count", 5),
         )
+
+    # Propagate thumbnail_interval into every server's output.frame_interval.
+    if "thumbnail_interval" in updates:
+        new_interval = int(updates["thumbnail_interval"])
+        media_servers = settings.get("media_servers") or []
+        updated_servers = []
+        changed = False
+        for entry in media_servers:
+            if not isinstance(entry, dict):
+                updated_servers.append(entry)
+                continue
+            output = dict(entry.get("output") or {})
+            if output.get("frame_interval") != new_interval:
+                output["frame_interval"] = new_interval
+                entry = dict(entry)
+                entry["output"] = output
+                changed = True
+            updated_servers.append(entry)
+        if changed:
+            settings.update({"media_servers": updated_servers})
+            logger.debug(
+                "Propagated thumbnail_interval={} to all server output configs",
+                new_interval,
+            )
 
     return thread_warning
 

--- a/media_preview_generator/web/routes/api_settings.py
+++ b/media_preview_generator/web/routes/api_settings.py
@@ -144,6 +144,17 @@ def _route_legacy_plex_fields_into_media_servers(settings, updates: dict) -> tup
     payload = {k: updates[k] for k in touched}
     new_updates = {k: v for k, v in updates.items() if k not in touched}
 
+    # Default frame_interval for any newly-synthesised / setdefault'd output
+    # block. Prefer the about-to-be-persisted update (so a wizard save that
+    # changes both plex_url and thumbnail_interval ends up with the new
+    # interval everywhere), then the already-persisted global, then the
+    # documented 10s default. Matches the read-side resolve_frame_interval
+    # fallback chain so writes can never disagree with subsequent reads.
+    default_interval = updates.get("thumbnail_interval") or settings.get("thumbnail_interval") or 10
+    default_interval = (
+        int(default_interval) if isinstance(default_interval, int) or str(default_interval).isdigit() else 10
+    )
+
     media_servers = list(settings.get("media_servers") or [])
     plex_index = next(
         (i for i, e in enumerate(media_servers) if isinstance(e, dict) and (e.get("type") or "").lower() == "plex"),
@@ -165,7 +176,7 @@ def _route_legacy_plex_fields_into_media_servers(settings, updates: dict) -> tup
             "libraries": [],
             "path_mappings": [],
             "exclude_paths": [],
-            "output": {"adapter": "plex_bundle", "plex_config_folder": "", "frame_interval": 10},
+            "output": {"adapter": "plex_bundle", "plex_config_folder": "", "frame_interval": default_interval},
         }
         media_servers.append(plex_entry)
         plex_index = len(media_servers) - 1
@@ -187,7 +198,7 @@ def _route_legacy_plex_fields_into_media_servers(settings, updates: dict) -> tup
     if "plex_config_folder" in payload:
         output = dict(plex_entry.get("output") or {})
         output.setdefault("adapter", "plex_bundle")
-        output.setdefault("frame_interval", 10)
+        output.setdefault("frame_interval", default_interval)
         output["plex_config_folder"] = str(payload["plex_config_folder"] or "").strip()
         plex_entry["output"] = output
     if "selected_libraries" in payload:

--- a/media_preview_generator/web/settings_manager.py
+++ b/media_preview_generator/web/settings_manager.py
@@ -340,8 +340,14 @@ class SettingsManager:
 
     @property
     def thumbnail_interval(self) -> int:
-        """Seconds between thumbnail captures."""
-        return int(self.get("thumbnail_interval") or 2)
+        """Seconds between thumbnail captures.
+
+        Defaults to 10 -- the BIF/Plex community convention (every sidecar
+        BIF in the wild follows ``-{width}-10.bif`` naming) and the Roku
+        spec example. Matches the read-side fallback in
+        :func:`media_preview_generator.config.resolve_frame_interval`.
+        """
+        return int(self.get("thumbnail_interval") or 10)
 
     @thumbnail_interval.setter
     def thumbnail_interval(self, value: int) -> None:

--- a/media_preview_generator/web/templates/settings.html
+++ b/media_preview_generator/web/templates/settings.html
@@ -199,11 +199,11 @@
                     <div class="col-md-6 mb-3">
                         <label for="thumbnailInterval" class="form-label">
                             Thumbnail Interval
-                            <button type="button" class="info-icon ms-1" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top" title="Seconds between thumbnails in the preview strip. Smaller = smoother scrubbing in your player, but bigger BIF files and longer to generate. Default 2s works well for most setups; raise to 5–10s if you don't need fine scrubbing and want faster jobs."><i class="bi bi-info-circle"></i></button>
+                            <button type="button" class="info-icon ms-1" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top" title="Seconds between thumbnails in the preview strip. Default 10s matches Plex's standard preview cadence and the BIF community convention — your existing sidecar BIFs (the -320-10.bif files alongside videos) use the same value. Lower to 5s for finer scrubbing if you don't mind bigger BIF files and longer jobs."><i class="bi bi-info-circle"></i></button>
                         </label>
                         <div class="input-group">
                             <input type="number" class="form-control has-stepper" id="thumbnailInterval"
-                                   min="1" max="60" value="2">
+                                   min="1" max="60" value="10">
                             <span class="input-group-text">seconds</span>
                         </div>
                     </div>
@@ -730,7 +730,7 @@ async function loadSettings() {
         // Store gpu_config for the GPU panel
         window._gpuConfig = settings.gpu_config || [];
         document.getElementById('cpuThreads').value = settings.cpu_threads ?? 1;
-        document.getElementById('thumbnailInterval').value = settings.thumbnail_interval || 2;
+        document.getElementById('thumbnailInterval').value = settings.thumbnail_interval || 10;
         document.getElementById('thumbnailQuality').value = settings.thumbnail_quality || 4;
         document.getElementById('qualityValue').textContent = settings.thumbnail_quality || 4;
         document.getElementById('tonemapAlgorithm').value = settings.tonemap_algorithm || 'hable';

--- a/tests/e2e/test_settings_page.py
+++ b/tests/e2e/test_settings_page.py
@@ -74,10 +74,13 @@ class TestSettingsSteppers:
 
     def test_thumbnail_interval_stepper_works(self, settings_page: Page) -> None:
         interval = settings_page.locator("#thumbnailInterval")
-        expect(interval).to_have_value("2")
+        # Default unified to 10s post-#238 (BIF/Plex community convention).
+        # See settings.html input value, settings_manager.thumbnail_interval,
+        # config/__init__.py loader default, and docs/reference.md.
+        expect(interval).to_have_value("10")
         plus = interval.locator(".. >> .stepper-plus").first
         plus.click()
-        expect(interval).to_have_value("3")
+        expect(interval).to_have_value("11")
 
     def test_log_rotation_stepper_works(self, settings_page: Page) -> None:
         rot = settings_page.locator("#logRotationSize")

--- a/tests/test_api_servers.py
+++ b/tests/test_api_servers.py
@@ -522,6 +522,146 @@ class TestCreateServer:
         assert existing["url"] == "http://emby"
 
 
+class TestCreateServerDefaultsFrameInterval:
+    """Issue #238 — creating a server without ``output.frame_interval`` must
+    default it to the user's current global ``thumbnail_interval``, not the
+    hardcoded 10.
+
+    Previously, a Jellyfin/Emby server added through the per-server modal
+    with no explicit ``frame_interval`` in the payload was persisted with
+    ``frame_interval`` missing from ``output``. The six read sites then
+    fell back to literal 10 regardless of what the user had configured
+    globally -- the exact configuration the user's settings.json exhibited
+    live (see plan write-up).
+    """
+
+    def test_emby_server_defaults_frame_interval_from_global(self, client, auth_headers):
+        # User's global is 5.
+        get_settings_manager().update({"thumbnail_interval": 5})
+
+        response = client.post(
+            "/api/servers",
+            headers=auth_headers,
+            json={
+                "type": "emby",
+                "name": "Emby",
+                "url": "http://emby:8096",
+                "auth": {"method": "api_key", "api_key": "secret"},
+                # NOTE: no "output" / no "frame_interval".
+            },
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+
+        body = response.get_json()
+        # The persisted entry must have frame_interval=5 (not 10, the old
+        # hardcoded default). Asserting on the persisted record rather than
+        # the API response so a "redacted response" regression can't mask
+        # the underlying storage state.
+        servers = get_settings_manager().get("media_servers")
+        created = next(s for s in servers if s["id"] == body["id"])
+        assert created["output"]["frame_interval"] == 5, (
+            f"server created with global thumbnail_interval=5 must inherit it; "
+            f"got frame_interval={created['output'].get('frame_interval')!r}"
+        )
+
+    def test_jellyfin_server_defaults_frame_interval_from_global(self, client, auth_headers):
+        """Same shape as the Emby row but for Jellyfin — different ``type``
+        means the validation branch differs (no _validate_plex_output) so
+        the create-flow default still must populate from global.
+
+        Together with the Emby + Plex rows, this completes the
+        per-server-type matrix the .claude/rules/testing.md "cover the
+        matrix" rule calls out — the D34 precedent showed that testing
+        one server type and not the others is exactly how a per-type
+        bug ships.
+        """
+        get_settings_manager().update({"thumbnail_interval": 4})
+
+        response = client.post(
+            "/api/servers",
+            headers=auth_headers,
+            json={
+                "type": "jellyfin",
+                "name": "Jellyfin",
+                "url": "http://jellyfin:8096",
+                "auth": {"method": "api_key", "api_key": "secret"},
+                # No "output" / no "frame_interval".
+            },
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+
+        body = response.get_json()
+        servers = get_settings_manager().get("media_servers")
+        created = next(s for s in servers if s["id"] == body["id"])
+        assert created["output"]["frame_interval"] == 4, (
+            f"jellyfin server created with global thumbnail_interval=4 must inherit it; "
+            f"got frame_interval={created['output'].get('frame_interval')!r}"
+        )
+
+    def test_plex_server_defaults_frame_interval_from_global(self, client, auth_headers, tmp_path):
+        """Plex create path runs through ``_validate_plex_output`` in addition
+        to the generic validator — this row pins that the frame_interval
+        default-from-global still kicks in for the Plex branch.
+
+        Plex requires a real ``plex_config_folder`` to satisfy the bundle
+        publisher's validation; the test creates a tmp_path-backed dir
+        so the test runs in both CI and dev environments.
+        """
+        plex_config = tmp_path / "plex_config"
+        plex_config.mkdir()
+        get_settings_manager().update({"thumbnail_interval": 6})
+
+        response = client.post(
+            "/api/servers",
+            headers=auth_headers,
+            json={
+                "type": "plex",
+                "name": "Plex",
+                "url": "http://plex:32400",
+                "auth": {"method": "token", "token": "secret-tok"},
+                "output": {
+                    "adapter": "plex_bundle",
+                    "plex_config_folder": str(plex_config),
+                    # NOTE: no "frame_interval" — must default from global.
+                },
+            },
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+
+        body = response.get_json()
+        servers = get_settings_manager().get("media_servers")
+        created = next(s for s in servers if s["id"] == body["id"])
+        assert created["output"]["frame_interval"] == 6, (
+            f"plex server created with global thumbnail_interval=6 must inherit it; "
+            f"got frame_interval={created['output'].get('frame_interval')!r}"
+        )
+
+    def test_explicit_frame_interval_in_payload_wins_over_global(self, client, auth_headers):
+        """If a script/client explicitly POSTs frame_interval=N, that wins over
+        the global. The per-server override is still allowed."""
+        get_settings_manager().update({"thumbnail_interval": 5})
+
+        response = client.post(
+            "/api/servers",
+            headers=auth_headers,
+            json={
+                "type": "jellyfin",
+                "name": "Jellyfin",
+                "url": "http://jellyfin:8096",
+                "auth": {"method": "api_key", "api_key": "secret"},
+                "output": {"adapter": "jellyfin_trickplay", "frame_interval": 3},
+            },
+        )
+        assert response.status_code == 201, response.get_data(as_text=True)
+
+        body = response.get_json()
+        servers = get_settings_manager().get("media_servers")
+        created = next(s for s in servers if s["id"] == body["id"])
+        assert created["output"]["frame_interval"] == 3, (
+            "explicit frame_interval in request payload must be preserved verbatim"
+        )
+
+
 class TestUpdateServer:
     def test_renames_server(self, client, auth_headers):
         _seed_media_servers(

--- a/tests/test_oauth_routes.py
+++ b/tests/test_oauth_routes.py
@@ -73,10 +73,13 @@ class TestSettingsAPIRoutes:
         # - plex_url falls through to "" when neither media_servers nor the
         #   legacy plex_url is set
         # - gpu_threads is computed from gpu_config (empty -> 0)
-        # - thumbnail_interval default is 2 (settings_manager.py:344)
+        # - thumbnail_interval default is 10s -- the BIF/Plex community
+        #   convention and the value every other site in the codebase
+        #   converged on after #238 (settings_manager.py:344,
+        #   config/__init__.py:509, settings.html, docs/reference.md)
         assert data["plex_url"] == ""
         assert data["gpu_threads"] == 0
-        assert data["thumbnail_interval"] == 2
+        assert data["thumbnail_interval"] == 10
         # Plex token must be returned masked (never raw) — the empty case
         # returns "" which the frontend treats as "not yet set".
         assert data["plex_token"] == ""

--- a/tests/test_settings_manager.py
+++ b/tests/test_settings_manager.py
@@ -881,3 +881,81 @@ class TestSingletonInitDeadlockRegression:
             )
         finally:
             reset_settings_manager()
+
+
+class TestResolveFrameInterval:
+    """Tests for ``config.resolve_frame_interval`` -- the read-side fallback (#238).
+
+    Lookup order under test:
+      1. ``server_output["frame_interval"]`` -- per-server override wins when set.
+      2. The global ``thumbnail_interval`` from the SettingsManager singleton.
+      3. The documented 10s default.
+
+    The helper is what stops the BIF multiplier from disagreeing with FFmpeg's
+    extraction cadence when a server entry is missing ``output.frame_interval``
+    -- the configuration the user's own settings exhibited live for Jellyfin
+    and Emby (see plan write-up).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self, tmp_path, monkeypatch):
+        from media_preview_generator.web.settings_manager import reset_settings_manager
+
+        monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+        reset_settings_manager()
+        yield
+        reset_settings_manager()
+
+    def test_returns_per_server_value_when_set(self):
+        from media_preview_generator.config import resolve_frame_interval
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().update({"thumbnail_interval": 5})  # global is 5
+
+        # Per-server explicitly set to 3 -- wins over global.
+        assert resolve_frame_interval({"frame_interval": 3}) == 3
+
+    def test_falls_back_to_global_when_per_server_missing(self):
+        from media_preview_generator.config import resolve_frame_interval
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().update({"thumbnail_interval": 7})
+
+        # Output dict has no frame_interval key -- must use global, not 10.
+        assert resolve_frame_interval({"adapter": "jellyfin_trickplay"}) == 7
+
+    def test_falls_back_to_global_when_output_is_none(self):
+        from media_preview_generator.config import resolve_frame_interval
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().update({"thumbnail_interval": 4})
+
+        assert resolve_frame_interval(None) == 4
+
+    def test_rejects_non_int_per_server_value(self):
+        """A garbage frame_interval (e.g. string from a hand-edit) must not poison
+        the chain; we fall through to the global instead of crashing or returning
+        a non-int."""
+        from media_preview_generator.config import resolve_frame_interval
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().update({"thumbnail_interval": 6})
+
+        assert resolve_frame_interval({"frame_interval": "not-a-number"}) == 6
+
+    def test_rejects_zero_per_server_value(self):
+        from media_preview_generator.config import resolve_frame_interval
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().update({"thumbnail_interval": 8})
+
+        # 0 would cause divide-by-zero in fps = 1/interval; fall through.
+        assert resolve_frame_interval({"frame_interval": 0}) == 8
+
+    def test_final_fallback_to_ten_when_nothing_set(self):
+        """No per-server override, no global setting -- documented 10s default."""
+        from media_preview_generator.config import resolve_frame_interval
+
+        # SettingsManager singleton was reset by the fixture; .get returns None.
+        assert resolve_frame_interval({}) == 10
+        assert resolve_frame_interval(None) == 10

--- a/tests/test_thumbnail_interval_propagation.py
+++ b/tests/test_thumbnail_interval_propagation.py
@@ -1,0 +1,228 @@
+"""Issue #238 — global ``thumbnail_interval`` must propagate to every server.
+
+Closes the gap PR #240 fixes. The global ``thumbnail_interval`` drives the
+FFmpeg ``fps`` argument, but the per-server ``media_servers[i].output.frame_interval``
+drives the BIF header multiplier, Jellyfin trickplay registration, Emby
+sidecar filename, and the BIF viewer's declared cadence. When they diverge,
+the BIF declares a different cadence from the extraction rate and Plex
+previews drift out of sync with playback.
+
+Production wiring at ``api_settings.py:_apply_post_save_hooks`` step 6:
+
+    if "thumbnail_interval" in updates:
+        # ... iterate media_servers, set output.frame_interval to new global
+
+This file pins:
+
+  1. Saving a new ``thumbnail_interval`` updates ``output.frame_interval``
+     in every server (Plex + Jellyfin + Emby), including entries that have
+     no ``output`` block at all (the Jellyfin/Emby drift the user's own
+     settings exhibited live — see plan write-up).
+  2. The hook is a no-op when already aligned — the ``changed`` guard PR #240
+     added must hold so no spurious settings.update() fires on every save.
+  3. The hook does NOT fire when ``thumbnail_interval`` is absent from the
+     ``updates`` dict — saving an unrelated field (e.g. ``cpu_threads``)
+     must not touch per-server intervals.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from media_preview_generator.web.app import create_app
+from media_preview_generator.web.routes.api_settings import _apply_post_save_hooks
+from media_preview_generator.web.settings_manager import (
+    get_settings_manager,
+    reset_settings_manager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    reset_settings_manager()
+    import media_preview_generator.web.jobs as jobs_mod
+
+    with jobs_mod._job_lock:
+        jobs_mod._job_manager = None
+    import media_preview_generator.web.scheduler as sched_mod
+
+    with sched_mod._schedule_lock:
+        sched_mod._schedule_manager = None
+    yield
+    reset_settings_manager()
+    with jobs_mod._job_lock:
+        jobs_mod._job_manager = None
+    with sched_mod._schedule_lock:
+        if sched_mod._schedule_manager is not None:
+            try:
+                sched_mod._schedule_manager.stop()
+            except Exception:
+                pass
+            sched_mod._schedule_manager = None
+
+
+@pytest.fixture()
+def app(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("WEB_AUTH_TOKEN", "test-token-12345678")
+    return create_app(config_dir=str(tmp_path))
+
+
+def _plex_entry(server_id: str, frame_interval: int | None = 10) -> dict:
+    output: dict = {"adapter": "plex_bundle", "plex_config_folder": "/plex"}
+    if frame_interval is not None:
+        output["frame_interval"] = frame_interval
+    return {
+        "id": server_id,
+        "type": "plex",
+        "name": f"Plex {server_id}",
+        "enabled": True,
+        "url": "http://plex:32400",
+        "auth": {"token": "plex-tok"},
+        "output": output,
+    }
+
+
+def _jellyfin_entry(server_id: str, frame_interval: int | None = None) -> dict:
+    output: dict = {"adapter": "jellyfin_trickplay"}
+    if frame_interval is not None:
+        output["frame_interval"] = frame_interval
+    return {
+        "id": server_id,
+        "type": "jellyfin",
+        "name": f"Jellyfin {server_id}",
+        "enabled": True,
+        "url": "http://jellyfin:8096",
+        "auth": {"api_key": "jf-key"},
+        "output": output,
+    }
+
+
+def _emby_entry(server_id: str, frame_interval: int | None = None) -> dict:
+    output: dict = {"adapter": "emby_sidecar"}
+    if frame_interval is not None:
+        output["frame_interval"] = frame_interval
+    return {
+        "id": server_id,
+        "type": "emby",
+        "name": f"Emby {server_id}",
+        "enabled": True,
+        "url": "http://emby:8096",
+        "auth": {"api_key": "emby-key"},
+        "output": output,
+    }
+
+
+class TestThumbnailIntervalPropagation:
+    """Direct unit tests for ``_apply_post_save_hooks`` step 6."""
+
+    def test_propagates_to_every_server(self, app):
+        """Plex stale at 10, Jellyfin/Emby missing entirely — all become 5.
+
+        The persisted ``thumbnail_interval`` in settings deliberately disagrees
+        with the value passed in ``updates``. The SUT must propagate the
+        ``updates`` value (the about-to-be-saved new global), not whatever
+        was already in settings — otherwise a save changing the value would
+        silently re-apply the OLD value to per-server entries. This pins
+        which side of the contract the hook reads from.
+        """
+        with app.app_context():
+            sm = get_settings_manager()
+            sm.update(
+                {
+                    "media_servers": [
+                        _plex_entry("plex-1", frame_interval=10),
+                        _jellyfin_entry("jf-1", frame_interval=None),
+                        _emby_entry("emby-1", frame_interval=None),
+                    ],
+                    "thumbnail_interval": 99,  # deliberately != the updates value
+                }
+            )
+
+            _apply_post_save_hooks(sm, {"thumbnail_interval": 5}, {"thumbnail_interval"})
+
+            servers = sm.get("media_servers")
+            assert len(servers) == 3, "no server entries should be added or dropped"
+            # Bug-blind check would be ``len(servers) == 3`` alone, or asserting
+            # ``== 99`` (which a regression that read from settings would also
+            # pass). Assert the post-condition that actually pins the contract:
+            # every entry's output.frame_interval == 5 (the updates value),
+            # regardless of vendor, starting state, or what settings held.
+            for entry in servers:
+                actual = entry.get("output", {}).get("frame_interval")
+                assert actual == 5, (
+                    f"server {entry['id']!r} ({entry['type']}) has "
+                    f"frame_interval={actual!r}; expected 5 from the updates "
+                    f"dict (not 99 from already-persisted settings)"
+                )
+
+    def test_creates_output_block_when_missing(self, app):
+        """An entry with no ``output`` key at all gets one with frame_interval set."""
+        with app.app_context():
+            sm = get_settings_manager()
+            no_output_entry = {
+                "id": "jf-bare",
+                "type": "jellyfin",
+                "name": "Jellyfin (no output)",
+                "enabled": True,
+                "url": "http://jellyfin:8096",
+                "auth": {"api_key": "key"},
+                # NOTE: deliberately no "output" key.
+            }
+            sm.update({"media_servers": [no_output_entry], "thumbnail_interval": 7})
+
+            _apply_post_save_hooks(sm, {"thumbnail_interval": 7}, {"thumbnail_interval"})
+
+            servers = sm.get("media_servers")
+            assert servers[0]["output"]["frame_interval"] == 7, (
+                "missing output block must be created with the propagated frame_interval"
+            )
+
+    def test_noop_when_already_aligned(self, app):
+        """All servers already at 10 + saving 10 → no settings churn."""
+        with app.app_context():
+            sm = get_settings_manager()
+            sm.update(
+                {
+                    "media_servers": [
+                        _plex_entry("plex-1", frame_interval=10),
+                        _jellyfin_entry("jf-1", frame_interval=10),
+                    ],
+                    "thumbnail_interval": 10,
+                }
+            )
+
+            before = sm.get("media_servers")
+            _apply_post_save_hooks(sm, {"thumbnail_interval": 10}, {"thumbnail_interval"})
+            after = sm.get("media_servers")
+
+            # The exact dict values should be byte-identical; the hook's
+            # ``if changed`` guard from PR #240 must hold or it would re-persist
+            # the same list every save.
+            assert before == after, "no-op save should not mutate media_servers when already aligned"
+
+    def test_does_not_fire_when_thumbnail_interval_absent_from_updates(self, app):
+        """Saving an unrelated field (cpu_threads) must NOT touch per-server intervals."""
+        with app.app_context():
+            sm = get_settings_manager()
+            sm.update(
+                {
+                    "media_servers": [
+                        _plex_entry("plex-1", frame_interval=10),
+                        _jellyfin_entry("jf-1", frame_interval=None),  # missing on purpose
+                    ],
+                    "thumbnail_interval": 5,
+                    "cpu_threads": 2,
+                }
+            )
+
+            # Simulate "user saved only cpu_threads" — thumbnail_interval not in updates.
+            _apply_post_save_hooks(sm, {"cpu_threads": 4}, {"cpu_threads"})
+
+            servers = sm.get("media_servers")
+            # Plex stays at 10 (its previous value), Jellyfin stays missing.
+            # Critically, the hook MUST NOT silently rewrite frame_interval
+            # using whatever global is currently in settings — that would
+            # introduce surprising side-effects on unrelated saves.
+            assert servers[0]["output"]["frame_interval"] == 10
+            assert "frame_interval" not in servers[1]["output"]

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1756,6 +1756,46 @@ class TestMigrationNoticeUserFacingSplit:
             f"Dev 'vN:' prefix leaked into user notice: {notes}"
         )
 
+    def test_v13_emits_friendly_user_string(self, settings_manager):
+        """Starting at v12 with a drifted per-server frame_interval, the v13
+        migration must emit the friendly summary copy ("now applies to every
+        server consistently") and never leak the dev ``v13: aligned N
+        server(s)...`` log string into the dashboard notice.
+
+        Same shape as the v7+v11 test above, scoped to v13's contract."""
+        from media_preview_generator.upgrade import _migrate_schema
+
+        # Start at v12 so v7..v12 are all skipped and only v13 fires.
+        # Drift: thumbnail_interval=5 globally, Plex entry stuck at 10.
+        settings_manager.apply_changes(
+            updates={
+                "_schema_version": 12,
+                "thumbnail_interval": 5,
+                "media_servers": [
+                    {
+                        "id": "abc123",
+                        "type": "plex",
+                        "name": "Plex",
+                        "enabled": True,
+                        "url": "http://plex:32400",
+                        "auth": {"token": "tok"},
+                        "output": {"frame_interval": 10},  # stale
+                    },
+                ],
+            }
+        )
+        _migrate_schema(settings_manager)
+
+        notice = settings_manager.get("_pending_migration_notice") or {}
+        notes = notice.get("notes") or []
+        assert len(notes) == 1, f"expected 1 user note (v13 only), got {len(notes)}: {notes}"
+        joined = notes[0]
+        assert "every server consistently" in joined, (
+            f"v13 user-facing note missing the expected friendly copy: {notes}"
+        )
+        assert not joined.startswith("v13:"), f"Dev-facing 'v13:' prefix leaked into user notice: {notes}"
+        assert "aligned" not in joined, f"Dev string token 'aligned N server(s)' leaked into user notice: {notes}"
+
     def test_unmapped_migration_produces_no_user_note(self, settings_manager):
         """A migration without a ``_USER_FACING_NOTES`` entry must be silent
         in the dashboard, not leak its dev log copy. Guards against a future
@@ -1879,3 +1919,186 @@ class TestReleaseNotesBundle:
 
         out = api_system._fetch_github_releases(limit=10)
         assert out == []
+
+
+class TestMigrateToV13:
+    """Tests for the v13 frame_interval alignment migration (#238).
+
+    The migration walks every server in ``media_servers`` and rewrites
+    ``output.frame_interval`` to match the global ``thumbnail_interval``.
+    It must heal three drift shapes the user's own settings exhibited:
+
+      a) Stale per-server value (e.g. Plex output.frame_interval=10 while
+         global has been changed to 2)
+      b) Missing per-server value entirely (the Jellyfin/Emby case — output
+         exists but has no frame_interval key, so reads fall back to 10)
+      c) Missing output block entirely (no output key at all)
+
+    And it must be a no-op when:
+      d) Already aligned across all servers
+      e) Global thumbnail_interval not set (nothing to align to)
+      f) media_servers empty or absent
+    """
+
+    def test_aligns_stale_per_server_value(self, settings_manager):
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "thumbnail_interval": 2,
+                "media_servers": [
+                    {
+                        "id": "plex-1",
+                        "type": "plex",
+                        "output": {"frame_interval": 10},  # stale
+                    },
+                ],
+            }
+        )
+
+        notes = _migrate_to_v13(settings_manager)
+
+        servers = settings_manager.get("media_servers")
+        assert servers[0]["output"]["frame_interval"] == 2
+        assert any("v13: aligned 1 server" in n for n in notes), (
+            f"migration must report alignment in its notes; got {notes!r}"
+        )
+
+    def test_fills_missing_frame_interval_key(self, settings_manager):
+        """Output dict exists but ``frame_interval`` is missing entirely."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "thumbnail_interval": 5,
+                "media_servers": [
+                    {
+                        "id": "jf-1",
+                        "type": "jellyfin",
+                        "output": {"adapter": "jellyfin_trickplay"},  # no frame_interval
+                    },
+                ],
+            }
+        )
+
+        _migrate_to_v13(settings_manager)
+
+        servers = settings_manager.get("media_servers")
+        assert servers[0]["output"]["frame_interval"] == 5
+
+    def test_creates_output_block_when_missing(self, settings_manager):
+        """Entry with no output key at all gets one with frame_interval set."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "thumbnail_interval": 7,
+                "media_servers": [
+                    {
+                        "id": "emby-1",
+                        "type": "emby",
+                        # NOTE: no "output" key at all.
+                    },
+                ],
+            }
+        )
+
+        _migrate_to_v13(settings_manager)
+
+        servers = settings_manager.get("media_servers")
+        assert servers[0]["output"]["frame_interval"] == 7
+
+    def test_handles_full_drift_matrix(self, settings_manager):
+        """One server stale (Plex), one missing key (Jellyfin), one missing output (Emby)
+        — the exact mix the user's live settings.json exhibited. All three heal to global."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "thumbnail_interval": 2,
+                "media_servers": [
+                    {"id": "plex-1", "type": "plex", "output": {"frame_interval": 10}},
+                    {"id": "jf-1", "type": "jellyfin", "output": {"adapter": "jellyfin_trickplay"}},
+                    {"id": "emby-1", "type": "emby"},
+                ],
+            }
+        )
+
+        notes = _migrate_to_v13(settings_manager)
+
+        servers = settings_manager.get("media_servers")
+        for entry in servers:
+            actual = entry.get("output", {}).get("frame_interval")
+            assert actual == 2, f"server {entry['id']!r}: expected 2, got {actual!r}"
+        assert any("v13: aligned 3 server" in n for n in notes), (
+            f"migration must report aligning all 3 servers; got {notes!r}"
+        )
+
+    def test_noop_when_already_aligned(self, settings_manager):
+        """Idempotent on re-run — no notes, no settings.update churn."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "thumbnail_interval": 10,
+                "media_servers": [
+                    {"id": "plex-1", "type": "plex", "output": {"frame_interval": 10}},
+                ],
+            }
+        )
+
+        before = settings_manager.get("media_servers")
+        notes = _migrate_to_v13(settings_manager)
+        after = settings_manager.get("media_servers")
+
+        assert notes == [], f"already-aligned migration must produce no notes; got {notes!r}"
+        assert before == after, "no-op migration must not mutate media_servers"
+
+    def test_noop_when_no_global_interval(self, settings_manager):
+        """If neither ``thumbnail_interval`` nor ``plex_bif_frame_interval`` is set,
+        leave per-server entries alone — the read-side fallback handles the default."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "media_servers": [
+                    {"id": "plex-1", "type": "plex", "output": {"frame_interval": 10}},
+                ],
+            }
+        )
+        # Sanity: neither key is set
+        assert settings_manager.get("thumbnail_interval") in (None, "")
+        assert settings_manager.get("plex_bif_frame_interval") in (None, "")
+
+        notes = _migrate_to_v13(settings_manager)
+
+        assert notes == []
+        servers = settings_manager.get("media_servers")
+        assert servers[0]["output"]["frame_interval"] == 10  # unchanged
+
+    def test_falls_back_to_legacy_plex_bif_frame_interval_key(self, settings_manager):
+        """Old installs may only have ``plex_bif_frame_interval`` set, not the
+        modern ``thumbnail_interval``. Migration must honour the legacy key."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update(
+            {
+                "plex_bif_frame_interval": 3,
+                "media_servers": [
+                    {"id": "plex-1", "type": "plex", "output": {"frame_interval": 10}},
+                ],
+            }
+        )
+
+        _migrate_to_v13(settings_manager)
+
+        servers = settings_manager.get("media_servers")
+        assert servers[0]["output"]["frame_interval"] == 3
+
+    def test_handles_empty_media_servers(self, settings_manager):
+        """Empty list — no work, no error."""
+        from media_preview_generator.upgrade import _migrate_to_v13
+
+        settings_manager.update({"thumbnail_interval": 5, "media_servers": []})
+        notes = _migrate_to_v13(settings_manager)
+        assert notes == []


### PR DESCRIPTION
## Summary

`output.frame_interval` was being set at server creation and server update, but was not being updated if the user updated their `frame_interval` global settings.

## Changes

Adds a 6th step in `_apply_post_save_hooks` to iterate through servers and set their `frame_interval` to the global interval.

## Verification
- [X] Manually exercised the feature / bugfix in the web UI

## Related issues

Fixes #238
