### PR TITLE
fix(multi-plex): route library scans + Plex webhooks to the originating server (#244)

### DIFF
--- a/media_preview_generator/jobs/orchestrator.py
+++ b/media_preview_generator/jobs/orchestrator.py
@@ -427,7 +427,14 @@ def _enumerate_plex_full_scan_items(
     from ..processing import get_processor_for
     from ..servers.base import ServerType
 
-    plex_cfg = next((c for c in registry.configs() if c.type is ServerType.PLEX), None)
+    # Defence in depth for issue #244: the gate at
+    # :func:`_should_use_multi_server_full_scan` routes 2+ enabled Plex
+    # installs to the multi-server path, so reaching this site with more
+    # than one enabled Plex would itself be the bug. Filter on ``enabled``
+    # here too so a "[disabled Plex-A, enabled Plex-B]" layout doesn't
+    # connect to the disabled one when ``media_servers[0]`` happens to be
+    # disabled — the user's intent is the enabled server.
+    plex_cfg = next((c for c in registry.configs() if c.type is ServerType.PLEX and c.enabled), None)
     if plex_cfg is None:
         return
     plex_processor = get_processor_for(ServerType.PLEX)
@@ -1763,14 +1770,13 @@ def _should_use_multi_server_full_scan(config, pinned_type: str) -> bool:
     * Pinned to a non-Plex server.
     * No Plex configured at all.
     * At least one non-Plex server (Emby / Jellyfin) is enabled.
+    * Two or more enabled Plex servers are configured.
 
     The legacy Plex-only branch only fires for the pure single-Plex install.
-    Reason: :func:`_run_plex_full_scan_phase` builds its registry via
-    ``ServerRegistry.from_legacy_config`` which has empty per-server
-    path_mappings — on a multi-server install Plex items come back with
-    their remote view paths (``/media/Movies/...``) and every worker fails
-    with "source missing" because the registry doesn't know how to
-    translate those.
+    It enumerates exactly one Plex config (the first enabled match from
+    ``registry.configs()``) and has no notion of ``server_id_filter`` —
+    so on a 2-Plex install pinning to the second Plex would still scan
+    the first, silently. Issue #244 (May 2026) was the live reproducer.
     """
     no_webhook_paths = not getattr(config, "webhook_paths", None)
     if not no_webhook_paths:
@@ -1778,17 +1784,24 @@ def _should_use_multi_server_full_scan(config, pinned_type: str) -> bool:
     non_plex_pin = bool(pinned_type) and pinned_type != "plex"
     no_plex_at_all = not (config.plex_url and config.plex_token)
     has_non_plex_server = False
+    enabled_plex_count = 0
     try:
         from ..web.settings_manager import get_settings_manager
 
         raw = get_settings_manager().get("media_servers") or []
-        has_non_plex_server = any(
-            isinstance(e, dict) and (e.get("type") or "").lower() in ("emby", "jellyfin") and e.get("enabled", True)
-            for e in raw
-        )
+        for entry in raw:
+            if not isinstance(entry, dict) or not entry.get("enabled", True):
+                continue
+            entry_type = (entry.get("type") or "").lower()
+            if entry_type in ("emby", "jellyfin"):
+                has_non_plex_server = True
+            elif entry_type == "plex":
+                enabled_plex_count += 1
     except Exception:
         has_non_plex_server = False
-    return non_plex_pin or no_plex_at_all or has_non_plex_server
+        enabled_plex_count = 0
+    multi_plex = enabled_plex_count >= 2
+    return non_plex_pin or no_plex_at_all or has_non_plex_server or multi_plex
 
 
 def _maybe_log_path_mapping_misconfig(aggregate_outcome: dict, processed: int) -> bool:
@@ -2333,6 +2346,17 @@ def run_processing(
 
         if _should_use_multi_server_full_scan(config, pinned_type):
             library_ids = list(getattr(config, "plex_library_ids", None) or [])
+            # Operator breadcrumb so a multi-Plex install that just got
+            # routed through the fan-out path (issue #244 fix) can be
+            # spotted in logs without grepping the gate function. The
+            # pre-fix log trail was identical for legacy and multi-server
+            # paths, so a 2-Plex no-pin scan looked like it had always
+            # walked both servers when in fact it only walked the first.
+            logger.info(
+                "Full-scan dispatch: multi-server path (pin={!r}). Walks every "
+                "enabled server matching the pin; honours server_id_filter end-to-end.",
+                sid_filter,
+            )
             scan_warnings: list[str] = []
             outcome_counts = _run_full_scan_multi_server(
                 config,

--- a/media_preview_generator/web/webhooks.py
+++ b/media_preview_generator/web/webhooks.py
@@ -1411,6 +1411,8 @@ def _extract_plex_payload(req) -> tuple[dict | None, str | None]:
 
 def _resolve_plex_paths_from_rating_key(
     rating_key: int | str,
+    *,
+    server_id: str | None = None,
 ) -> tuple[list[str], str | None]:
     """Look up a Plex item by ratingKey and return its file paths and a
     formatted display title.
@@ -1422,11 +1424,19 @@ def _resolve_plex_paths_from_rating_key(
     derives a descriptive title from the same fetched item so callers
     don't need a second Plex round trip.
 
+    Args:
+        rating_key: The Plex ``ratingKey`` from the webhook Metadata.
+        server_id: Optional ``media_servers[].id`` pinning the lookup to
+            a specific Plex install. Required for multi-Plex installs —
+            without it the lookup projects from ``media_servers[0]`` and
+            misses every ratingKey owned only by the second (or later)
+            Plex. Issue #244 shadow in the webhook flow.
+
     Returns ``([], None)`` on any failure (item not found, Plex
     unreachable, no media parts).
     """
     try:
-        from ..config import load_config
+        from ..config import derive_legacy_plex_view, load_config
         from ..plex_client import plex_server, retry_plex_call
     except ImportError as exc:
         logger.debug("Webhook: cannot import plex client modules: {}", exc)
@@ -1446,6 +1456,27 @@ def _resolve_plex_paths_from_rating_key(
             exc,
         )
         return [], None
+
+    # Multi-Plex routing: when the caller knows which Plex sent the
+    # webhook (matched the payload's Server.uuid against
+    # server_identity), project that Plex's URL/token onto ``config``
+    # so the plex_server() call connects to the right server.
+    # Without this, ``load_config`` returns the legacy view derived
+    # from media_servers[0], and a Plex-B-only ratingKey lookup
+    # silently fails with "ratingKey not recognised".
+    try:
+        raw_servers = get_settings_manager().get("media_servers") or []
+        plex_view = derive_legacy_plex_view(raw_servers, server_id=server_id)
+        if plex_view.get("plex_url"):
+            config.plex_url = plex_view["plex_url"]
+        if plex_view.get("plex_token"):
+            config.plex_token = plex_view["plex_token"]
+    except Exception as exc:
+        logger.debug(
+            "Plex webhook lookup: per-server view projection failed ({}). "
+            "Falling back to load_config()'s default Plex.",
+            exc,
+        )
 
     try:
         plex = plex_server(config)
@@ -1566,13 +1597,117 @@ def _classify_plex_event(data: dict) -> tuple[str, tuple | None]:
     return event, None
 
 
-def _resolve_plex_webhook_paths_and_title(metadata: dict, rating_key) -> tuple[list[str], str]:
+def _resolve_plex_source_server_id(payload: dict) -> str | None:
+    """Map a native Plex webhook payload to a configured ``media_servers[].id``.
+
+    Two routing signals are checked, in precedence order:
+
+    1. ``?server_id=`` query string — explicit operator pin. The value
+       must match a persisted ``media_servers[].id`` exactly. Mirrors
+       the Sonarr/Radarr webhook pattern (webhooks.py:1325) and beats
+       any payload heuristic.
+    2. ``payload["Server"]["uuid"]`` — Plex sends the source server's
+       ``machineIdentifier`` in every webhook. We match it against each
+       enabled Plex's persisted ``server_identity`` (captured at
+       test-connection time). Locally-generated UUIDs never appear in
+       vendor payloads, so we match on identity, not id.
+
+    Returns ``None`` when nothing matches — the caller should treat that
+    as "fall back to media_servers[0]'s view," which preserves the
+    pre-fix behaviour for single-Plex installs and any payload that
+    can't be confidently disambiguated. Identity collisions (the
+    extremely rare cloned-VM case where two configured Plex installs
+    share the same machineIdentifier) also return ``None`` because we
+    can't tell which one to use; the warning matches webhook_router.py's
+    handling of the same case.
+    """
+    pin_id = (request.args.get("server_id") or "").strip() or None
+
+    raw_servers = []
+    try:
+        raw_servers = get_settings_manager().get("media_servers") or []
+    except Exception as exc:
+        logger.debug("Plex webhook routing: could not read media_servers ({}); falling back to no pin.", exc)
+        return pin_id if pin_id else None
+
+    if pin_id:
+        # Strict pin validation: id must point at an ENABLED PLEX entry.
+        # Accepting any id and letting ``derive_legacy_plex_view`` filter
+        # downstream would silently fall back to media_servers[0]'s view
+        # — the same first-Plex ghost this whole helper exists to
+        # eliminate — when the operator pinned a typo'd id, a disabled
+        # Plex, or (worse) an Emby/Jellyfin id by mistake.
+        match = next(
+            (
+                e
+                for e in raw_servers
+                if isinstance(e, dict)
+                and e.get("id") == pin_id
+                and (e.get("type") or "").lower() == "plex"
+                and e.get("enabled", True)
+            ),
+            None,
+        )
+        if match is not None:
+            return pin_id
+        logger.warning(
+            "Plex webhook routing: ``?server_id={!r}`` doesn't match any enabled Plex server "
+            "(it may be disabled, a different vendor, or a typo). Falling back to payload-uuid "
+            "matching. Check the URL registered with this Plex on the Servers page.",
+            pin_id,
+        )
+
+    server_block = payload.get("Server") if isinstance(payload, dict) else None
+    payload_uuid = ""
+    if isinstance(server_block, dict):
+        raw_uuid = server_block.get("uuid")
+        if isinstance(raw_uuid, str):
+            payload_uuid = raw_uuid.strip()
+    if not payload_uuid:
+        return None
+
+    matches = [
+        e
+        for e in raw_servers
+        if isinstance(e, dict)
+        and (e.get("type") or "").lower() == "plex"
+        and e.get("enabled", True)
+        and e.get("server_identity") == payload_uuid
+    ]
+    if len(matches) == 1:
+        return str(matches[0].get("id") or "") or None
+    if len(matches) > 1:
+        logger.warning(
+            "Plex webhook routing: two or more configured Plex servers share the same "
+            "machineIdentifier ({!r}, {} matches). Can't tell which one this webhook came from — "
+            "falling back to the default Plex view. Fix by re-installing one server so it has a "
+            "fresh identity, or pin the URL with ``?server_id=<id>``.",
+            payload_uuid,
+            len(matches),
+        )
+    return None
+
+
+def _resolve_plex_webhook_paths_and_title(
+    metadata: dict,
+    rating_key,
+    *,
+    server_id: str | None = None,
+) -> tuple[list[str], str]:
     """Recover the file paths + display title for a library.new Plex webhook.
 
     Tries the cheap path first: file paths embedded in the payload's
     ``Media[].Part[].file`` fields. Plex includes these inconsistently
     (present for some media types but not all), so falls back to a Plex
     API lookup by ratingKey when the embedded paths or title are missing.
+
+    Args:
+        metadata: The ``Metadata`` block of the Plex webhook payload.
+        rating_key: The Plex ``ratingKey`` from the same payload.
+        server_id: Optional ``media_servers[].id`` of the originating
+            Plex (resolved from the payload's ``Server.uuid`` or a
+            ``?server_id=`` query override). Forwarded to the ratingKey
+            lookup so multi-Plex installs hit the right server.
 
     Returns ``(paths, display_title)``. Either may be empty if every
     resolution strategy fails — the caller is responsible for the
@@ -1593,7 +1728,10 @@ def _resolve_plex_webhook_paths_and_title(metadata: dict, rating_key) -> tuple[l
                         paths.append(file_path.strip())
 
     if not paths or display_title is None:
-        resolved_paths, resolved_title = _resolve_plex_paths_from_rating_key(rating_key)
+        resolved_paths, resolved_title = _resolve_plex_paths_from_rating_key(
+            rating_key,
+            server_id=server_id,
+        )
         if not paths:
             paths = resolved_paths
         if display_title is None:
@@ -1642,6 +1780,22 @@ def plex_webhook():
     metadata = _as_dict(data.get("Metadata"))
     rating_key = metadata.get("ratingKey")
 
+    # Multi-Plex routing: figure out which configured Plex this webhook
+    # came from BEFORE we fall back to a ratingKey lookup that needs
+    # to hit that exact server. Two signals, in precedence:
+    #   1. ``?server_id=`` query string — explicit operator pin. Mirrors
+    #      the Sonarr webhook pattern at line 1325. Wins because it's
+    #      an explicit deployment decision, not a heuristic.
+    #   2. ``Server.uuid`` in the payload matched against each
+    #      configured Plex's persisted ``server_identity`` (captured
+    #      from a successful test-connection probe — Plex's
+    #      ``machineIdentifier``). The locally-generated id never
+    #      appears in vendor payloads, so we match on identity, not id.
+    # Falls back to ``None`` when nothing matches — single-Plex installs
+    # and unknown-identity multi-Plex installs both behave the same as
+    # they always did (project from media_servers[0]).
+    resolved_server_id = _resolve_plex_source_server_id(data)
+
     if not rating_key:
         raw_title = str(metadata.get("title", "")).strip() or "Plex item"
         fallback_display = _format_plex_title_from_metadata(metadata) or raw_title
@@ -1655,7 +1809,11 @@ def plex_webhook():
         _add_history_entry("plex", "library.new", fallback_display, "ignored_no_path")
         return jsonify({"success": False, "error": "Missing Metadata.ratingKey"}), 400
 
-    paths, display_title = _resolve_plex_webhook_paths_and_title(metadata, rating_key)
+    paths, display_title = _resolve_plex_webhook_paths_and_title(
+        metadata,
+        rating_key,
+        server_id=resolved_server_id,
+    )
 
     if not paths:
         logger.warning(
@@ -1677,7 +1835,20 @@ def plex_webhook():
             200,
         )
 
-    queued_any = any(_schedule_webhook_job("plex", display_title, path) for path in paths)
+    # Thread the resolved Plex server through to the dispatcher so:
+    #   1. The Jobs UI's source chip / server column shows the right Plex.
+    #   2. The dedup key ``(source, server_id, canonical_path)`` doesn't
+    #      collapse Plex-A and Plex-B events for the same path within the
+    #      60s window.
+    #   3. The orchestrator's full-scan gate (issue #244 part 1) sees a
+    #      pin and routes the webhook job to that Plex only — without
+    #      this the gate's ``enabled_plex_count >= 2`` branch fans the
+    #      path out to both Plex servers (double processing).
+    # Mirrors the Sonarr handler at line 1325-1329.
+    job_kwargs: dict = {}
+    if resolved_server_id:
+        job_kwargs["server_id"] = resolved_server_id
+    queued_any = any(_schedule_webhook_job("plex", display_title, path, **job_kwargs) for path in paths)
 
     if not queued_any:
         _add_history_entry("plex", "library.new", display_title, "ignored_no_path")

--- a/tests/test_orchestrator_multi_plex_routing.py
+++ b/tests/test_orchestrator_multi_plex_routing.py
@@ -1,0 +1,294 @@
+"""Regression: a full-library scan pinned to a non-first Plex server in a
+multi-Plex install must enumerate the PINNED server, not media_servers[0].
+
+This guards against GitHub issue #244: user had two Plex servers (no
+Emby/Jellyfin), pinned a library scan to the second Plex, the job ran
+against the first one. Root cause: ``_should_use_multi_server_full_scan``
+returned False for "2 Plex, no non-Plex" so dispatch fell through to the
+legacy ``_run_plex_full_scan_phase``, whose enumerator picked the first
+Plex out of ``registry.configs()`` and ignored ``config.server_id_filter``.
+
+The fix routes multi-Plex installs through ``_run_full_scan_multi_server``
+which honors ``server_id_filter`` (orchestrator.py:1552). Single-Plex
+installs keep their existing legacy path so the WorkerPool's
+``worker_pool_callback`` / ``item_complete_callback`` wiring is preserved.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from media_preview_generator.jobs.orchestrator import (
+    _should_use_multi_server_full_scan,
+    run_processing,
+)
+
+
+def _full_scan_config(server_id_filter: str | None = None):
+    """Bare config that satisfies ``run_processing``'s preconditions for a
+    legitimate full library scan (no webhook markers, Plex configured)."""
+    return SimpleNamespace(
+        webhook_paths=None,
+        webhook_source=None,
+        server_id_filter=server_id_filter,
+        plex_url="http://plex-a.example:32400",
+        plex_token="tok-a",
+        plex_library_ids=None,
+        gpu_threads=0,
+        cpu_threads=1,
+        working_tmp_folder="/tmp/test-multi-plex-routing-nonexistent",
+    )
+
+
+class TestShouldUseMultiServerFullScan:
+    """Pin the gate function itself — the matrix that decides which
+    dispatch path handles a full-library scan."""
+
+    def _with_servers(self, entries):
+        """Context manager-ish helper returning a patcher already started."""
+        patcher = patch("media_preview_generator.web.settings_manager.get_settings_manager")
+        mock_sm = patcher.start()
+        mock_sm.return_value.get.return_value = entries
+        return patcher
+
+    def test_single_plex_uses_legacy_path(self):
+        """One enabled Plex, no pin → legacy path (preserves current
+        single-Plex behaviour, including WorkerPool callbacks)."""
+        patcher = self._with_servers([{"id": "plex-a", "type": "plex", "enabled": True}])
+        try:
+            config = _full_scan_config(server_id_filter=None)
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is False
+        finally:
+            patcher.stop()
+
+    def test_two_enabled_plex_servers_routes_through_multi_server(self):
+        """The #244 bug: two enabled Plex servers MUST route through the
+        multi-server path so ``server_id_filter`` is honoured. Without
+        this the legacy enumerator picks ``media_servers[0]`` regardless
+        of the pin and the second Plex is silently never scanned."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter="plex-b")
+            assert _should_use_multi_server_full_scan(config, pinned_type="plex") is True
+        finally:
+            patcher.stop()
+
+    def test_two_enabled_plex_no_pin_also_routes_multi_server(self):
+        """Even without a pin, two enabled Plex installs must use the
+        multi-server path — the legacy enumerator's first-Plex-wins
+        semantics would silently scan only one of them."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter=None)
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is True
+        finally:
+            patcher.stop()
+
+    def test_disabled_second_plex_keeps_legacy_path(self):
+        """One enabled + one disabled Plex → still one effective Plex,
+        legacy path is fine. The ``enabled`` flag is the user's intent
+        and must be respected."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": False},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter=None)
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is False
+        finally:
+            patcher.stop()
+
+    def test_mixed_install_still_routes_multi_server(self):
+        """Control: existing behaviour for Plex + Jellyfin must remain
+        unchanged — multi-server path."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "jf-1", "type": "jellyfin", "enabled": True},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter=None)
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is True
+        finally:
+            patcher.stop()
+
+    def test_three_enabled_plex_routes_multi_server(self):
+        """The ``>= 2`` predicate must hold for any larger N. A user
+        consolidating three Plex servers under one runner is an explicit
+        operator setup; legacy first-Plex-wins would silently hide two
+        of them."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+                {"id": "plex-c", "type": "plex", "enabled": True},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter=None)
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is True
+        finally:
+            patcher.stop()
+
+    def test_pin_to_disabled_plex_in_single_enabled_install(self):
+        """Pin set to a Plex that exists but is disabled. With only one
+        enabled Plex (the *other* one), ``multi_plex`` is False and the
+        gate keeps the legacy path — the enumerator then picks the
+        enabled Plex (defence in depth at line 437) and the pin is
+        effectively ignored. This is a graceful fallback, not silent
+        wrong-server scanning — the user's effective Plex is the
+        enabled one regardless of pin."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": False},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter="plex-b")
+            assert _should_use_multi_server_full_scan(config, pinned_type="plex") is False
+        finally:
+            patcher.stop()
+
+    def test_pin_to_ghost_id_in_multi_plex(self):
+        """Pin set to a server-id that doesn't match any configured
+        Plex. With 2+ enabled Plex servers the gate routes to the
+        multi-server path regardless, where the no-candidates warning
+        (orchestrator.py:1555-1558) gives the operator a clean signal
+        instead of a silent first-Plex scan."""
+        patcher = self._with_servers(
+            [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+            ]
+        )
+        try:
+            config = _full_scan_config(server_id_filter="plex-ghost")
+            assert _should_use_multi_server_full_scan(config, pinned_type="") is True
+        finally:
+            patcher.stop()
+
+
+class TestRunProcessingRoutesMultiPlex:
+    """Integration: assert ``run_processing`` actually picks the right
+    branch and forwards the pin. This is the high-level contract that
+    matters to the user — patching only the boundary makes the test
+    bug-blind (the legacy path could be called with the wrong pin and
+    the test would still pass)."""
+
+    def test_multi_plex_pin_calls_multi_server_with_pin(self):
+        """The full chain: 2-Plex install + Plex pin → dispatch hits
+        ``_run_full_scan_multi_server`` with ``server_id_filter`` set to
+        the pin. The legacy ``_run_plex_full_scan_phase`` must NOT be
+        called — that path's enumerator picks ``media_servers[0]`` and
+        the second Plex would never be scanned."""
+        config = _full_scan_config(server_id_filter="plex-b")
+        with (
+            patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
+            patch(
+                "media_preview_generator.jobs.orchestrator._run_full_scan_multi_server",
+                return_value={"generated": 0},
+            ) as mock_multi,
+            patch("media_preview_generator.jobs.orchestrator._run_plex_full_scan_phase") as mock_legacy,
+        ):
+            mock_sm.return_value.get.return_value = [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+            ]
+            run_processing(config, selected_gpus=[])
+
+        mock_legacy.assert_not_called()
+        mock_multi.assert_called_once()
+        # Pin must be forwarded — without this assertion the test is
+        # bug-blind (D34-shape regression: multi-server path called but
+        # with the wrong pin). The fix's whole point is that "plex-b"
+        # gets all the way down to the enumerator's filter.
+        assert mock_multi.call_args.kwargs.get("server_id_filter") == "plex-b"
+
+    def test_single_plex_pin_still_uses_legacy_path(self):
+        """Control: single-Plex installs keep using the legacy path so
+        no callback wiring is silently lost. The pin matches the only
+        Plex configured, so the legacy enumerator's first-Plex-wins
+        semantics happen to do the right thing here."""
+        config = _full_scan_config(server_id_filter="plex-only")
+        with (
+            patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
+            patch("media_preview_generator.jobs.orchestrator._run_full_scan_multi_server") as mock_multi,
+            patch(
+                "media_preview_generator.jobs.orchestrator._run_plex_full_scan_phase",
+                return_value=True,
+            ) as mock_legacy,
+        ):
+            mock_sm.return_value.get.return_value = [
+                {"id": "plex-only", "type": "plex", "enabled": True},
+            ]
+            run_processing(config, selected_gpus=[])
+
+        mock_multi.assert_not_called()
+        mock_legacy.assert_called_once()
+
+
+class TestEnumeratorPicksEnabledPlex:
+    """Defence in depth at the legacy enumerator: even if the gate ever
+    regresses and lets a "[disabled-first, enabled-second]" layout
+    through, the enumerator must pick the *enabled* Plex — never connect
+    to a server the user explicitly turned off."""
+
+    def test_picks_enabled_when_first_config_is_disabled(self):
+        """Layout: ``media_servers=[disabled Plex-A, enabled Plex-B]``.
+        The enumerator must select Plex-B and call its
+        ``list_canonical_paths`` — connecting to Plex-A here would be
+        the bug shape (disabled server still queried).
+        """
+        from unittest.mock import MagicMock
+
+        from media_preview_generator.jobs.orchestrator import _enumerate_plex_full_scan_items
+        from media_preview_generator.servers.base import ServerType
+
+        disabled_cfg = MagicMock()
+        disabled_cfg.type = ServerType.PLEX
+        disabled_cfg.enabled = False
+        disabled_cfg.id = "plex-a"
+        disabled_cfg.name = "Plex-A"
+
+        enabled_cfg = MagicMock()
+        enabled_cfg.type = ServerType.PLEX
+        enabled_cfg.enabled = True
+        enabled_cfg.id = "plex-b"
+        enabled_cfg.name = "Plex-B"
+
+        registry = MagicMock()
+        registry.configs.return_value = [disabled_cfg, enabled_cfg]
+
+        config = SimpleNamespace(plex_library_ids=None)
+
+        processor = MagicMock()
+        processor.list_canonical_paths.return_value = iter([])
+
+        with patch(
+            "media_preview_generator.processing.get_processor_for",
+            return_value=processor,
+        ):
+            list(_enumerate_plex_full_scan_items(config, registry))
+
+        # Pin the SUT's contract: the *enabled* Plex's config is what
+        # gets handed to the processor — not media_servers[0].
+        processor.list_canonical_paths.assert_called_once()
+        call_args = processor.list_canonical_paths.call_args
+        assert call_args.args[0] is enabled_cfg, (
+            f"enumerator passed wrong ServerConfig: expected enabled Plex-B, got {call_args.args[0]!r}"
+        )

--- a/tests/test_webhooks_plex_multi_server_routing.py
+++ b/tests/test_webhooks_plex_multi_server_routing.py
@@ -1,0 +1,552 @@
+"""Regression: a native Plex ``library.new`` webhook fired by Plex-B
+must resolve the ratingKey against Plex-B, not media_servers[0].
+
+This is the multi-Plex shadow of issue #244 in the webhook flow. The
+library-scan path (orchestrator gate) was the user-facing report; this
+file pins the second half — when Plex's payload omits file paths under
+``Metadata.Media[].Part[].file`` and the resolver has to look the item
+up by ratingKey, the lookup MUST happen on the originating Plex (the
+one Plex sent the webhook from). Pre-fix, ``_resolve_plex_paths_from_rating_key``
+called ``load_config()`` → ``derive_legacy_plex_view(...)`` with no
+``server_id`` argument, so it always projected ``media_servers[0]``'s
+URL/token — guaranteed to return ``[]`` for a Plex-B-only ratingKey.
+
+The router has the information needed to disambiguate: Plex's webhook
+payload carries ``Server.uuid`` (the source server's machineIdentifier).
+``servers.registry.server_config_from_dict`` already stores each
+configured Plex's ``server_identity`` from the test-connection probe,
+so the webhook handler can match the inbound uuid to a media_servers[]
+entry and forward that entry's id to the resolver.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from media_preview_generator.web.app import create_app
+from media_preview_generator.web.settings_manager import reset_settings_manager
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    """Mirror the reset fixture from test_webhooks_plex.py."""
+    reset_settings_manager()
+    import media_preview_generator.web.jobs as jobs_mod
+
+    with jobs_mod._job_lock:
+        jobs_mod._job_manager = None
+    import media_preview_generator.web.scheduler as sched_mod
+
+    with sched_mod._schedule_lock:
+        sched_mod._schedule_manager = None
+    from media_preview_generator.web.routes import clear_gpu_cache
+
+    clear_gpu_cache()
+    import media_preview_generator.web.webhooks as wh
+
+    wh._webhook_history.clear()
+    with wh._pending_lock:
+        for t in wh._pending_timers.values():
+            t.cancel()
+        wh._pending_timers.clear()
+        wh._pending_batches.clear()
+        wh._recent_dispatches.clear()
+    yield
+    reset_settings_manager()
+    with jobs_mod._job_lock:
+        jobs_mod._job_manager = None
+    with sched_mod._schedule_lock:
+        if sched_mod._schedule_manager is not None:
+            try:
+                sched_mod._schedule_manager.stop()
+            except Exception:
+                pass
+            sched_mod._schedule_manager = None
+    clear_gpu_cache()
+    wh._webhook_history.clear()
+    with wh._pending_lock:
+        for t in wh._pending_timers.values():
+            t.cancel()
+        wh._pending_timers.clear()
+        wh._pending_batches.clear()
+        wh._recent_dispatches.clear()
+
+
+@pytest.fixture()
+def app(tmp_path):
+    """Create a Flask app pinned to a tmp ``CONFIG_DIR``.
+
+    media_servers is NOT written to the on-disk settings.json — instead
+    the integration tests set it via the live ``settings_manager`` after
+    create_app. Writing it to disk via the fixture risked the
+    schema-upgrade pipeline persisting it back to ``/config`` in some
+    failure modes, polluting the dev box's real config.
+    """
+    config_dir = str(tmp_path / "config")
+    os.makedirs(config_dir, exist_ok=True)
+
+    auth_file = os.path.join(config_dir, "auth.json")
+    with open(auth_file, "w") as f:
+        json.dump({"token": "test-token-12345678"}, f)
+
+    settings_file = os.path.join(config_dir, "settings.json")
+    with open(settings_file, "w") as f:
+        json.dump(
+            {
+                "setup_complete": True,
+                "webhook_enabled": True,
+            },
+            f,
+        )
+
+    with patch.dict(
+        os.environ,
+        {
+            "CONFIG_DIR": config_dir,
+            "WEB_AUTH_TOKEN": "test-token-12345678",
+            "WEB_PORT": "8099",
+        },
+    ):
+        flask_app = create_app(config_dir=config_dir)
+        flask_app.config["TESTING"] = True
+        flask_app.config["WTF_CSRF_ENABLED"] = False
+        yield flask_app
+
+
+@pytest.fixture()
+def two_plex_servers():
+    """Inject a two-Plex ``media_servers`` array via the live singleton
+    AFTER create_app has bound it to the tmp config dir. Returns the
+    raw list so tests can mutate it before posting if needed."""
+    from media_preview_generator.web.settings_manager import get_settings_manager
+
+    entries = [
+        {
+            "id": "plex-a",
+            "type": "plex",
+            "enabled": True,
+            "server_identity": "mid-a",
+            "url": "http://plex-a:32400",
+            "auth": {"token": "tok-a"},
+        },
+        {
+            "id": "plex-b",
+            "type": "plex",
+            "enabled": True,
+            "server_identity": "mid-b",
+            "url": "http://plex-b:32400",
+            "auth": {"token": "tok-b"},
+        },
+    ]
+    get_settings_manager().set("media_servers", entries)
+    return entries
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _multipart_post(client, payload_dict, query: str = ""):
+    """POST a Plex-style multipart/form-data request to /api/webhooks/plex."""
+    return client.post(
+        f"/api/webhooks/plex{query}",
+        data={"payload": (io.BytesIO(json.dumps(payload_dict).encode()), "payload.json")},
+        content_type="multipart/form-data",
+        headers={"X-Auth-Token": "test-token-12345678"},
+    )
+
+
+class TestResolverAcceptsServerIdArg:
+    """Unit-level: the resolver must take a ``server_id`` kwarg and
+    forward it into ``derive_legacy_plex_view`` so the projected
+    ``plex_url`` / ``plex_token`` belong to the requested Plex, not
+    ``media_servers[0]``."""
+
+    def test_server_id_kwarg_flows_to_derive_legacy_plex_view(self):
+        """When the caller passes ``server_id="plex-b"``, the resolver
+        must call ``derive_legacy_plex_view`` with that exact id —
+        otherwise the projected legacy view falls back to the first
+        enabled Plex and the lookup misses every Plex-B-only ratingKey."""
+        from media_preview_generator.web.webhooks import _resolve_plex_paths_from_rating_key
+
+        mock_config = MagicMock()
+        mock_config.plex_url = "http://plex-b:32400"
+        mock_config.plex_token = "tok-b"
+
+        with (
+            patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
+            patch(
+                "media_preview_generator.config.load_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "media_preview_generator.config.derive_legacy_plex_view",
+                return_value={"plex_url": "http://plex-b:32400", "plex_token": "tok-b"},
+            ) as mock_derive,
+            patch(
+                "media_preview_generator.plex_client.plex_server",
+                return_value=MagicMock(fetchItem=MagicMock(side_effect=Exception("ratingKey not found"))),
+            ),
+        ):
+            mock_sm.return_value.get.return_value = [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+                {"id": "plex-b", "type": "plex", "enabled": True},
+            ]
+            _resolve_plex_paths_from_rating_key("777", server_id="plex-b")
+
+        mock_derive.assert_called_once()
+        assert mock_derive.call_args.kwargs.get("server_id") == "plex-b", (
+            f"derive_legacy_plex_view must receive server_id='plex-b' so the "
+            f"lookup hits Plex-B's URL/token, got kwargs={mock_derive.call_args.kwargs!r}"
+        )
+
+    def test_no_server_id_arg_preserves_existing_behaviour(self):
+        """Control: omitting ``server_id`` must keep the historical
+        ``media_servers[0]`` fallback so single-Plex installs and
+        callers that haven't been updated yet keep working."""
+        from media_preview_generator.web.webhooks import _resolve_plex_paths_from_rating_key
+
+        mock_config = MagicMock()
+
+        with (
+            patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
+            patch(
+                "media_preview_generator.config.load_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "media_preview_generator.config.derive_legacy_plex_view",
+                return_value={},
+            ) as mock_derive,
+            patch(
+                "media_preview_generator.plex_client.plex_server",
+                return_value=MagicMock(fetchItem=MagicMock(side_effect=Exception("nope"))),
+            ),
+        ):
+            mock_sm.return_value.get.return_value = [
+                {"id": "plex-a", "type": "plex", "enabled": True},
+            ]
+            _resolve_plex_paths_from_rating_key("777")
+
+        mock_derive.assert_called_once()
+        assert mock_derive.call_args.kwargs.get("server_id") is None
+
+
+class TestPlexWebhookRoutesToOriginatingServer:
+    """Integration: a ``library.new`` POST carrying ``Server.uuid=mid-b``
+    must trigger a ratingKey lookup against Plex-B, not Plex-A."""
+
+    def test_uuid_match_routes_to_originating_plex(self, client, two_plex_servers):
+        """Plex-B has machineIdentifier ``mid-b``. A webhook from Plex-B
+        must cause the ratingKey resolver to be called with
+        ``server_id="plex-b"`` — so the lookup uses Plex-B's URL/token
+        instead of defaulting to ``media_servers[0]``."""
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-b"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test Movie"),
+            ) as mock_resolve,
+            patch(
+                "media_preview_generator.web.webhooks._schedule_webhook_job",
+                return_value=True,
+            ) as mock_schedule,
+        ):
+            resp = _multipart_post(client, payload)
+
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+        mock_resolve.assert_called_once()
+        # Bug-blind guard #1 (ratingKey resolver): assert the ACTUAL
+        # server_id forwarded — not just that the resolver was called.
+        assert mock_resolve.call_args.kwargs.get("server_id") == "plex-b", (
+            f"resolver must receive server_id='plex-b' for a mid-b webhook, "
+            f"got kwargs={mock_resolve.call_args.kwargs!r}"
+        )
+        # Bug-blind guard #2 (dispatch site): the Sonarr handler already
+        # threads server_id into _schedule_webhook_job (webhooks.py:1325).
+        # The Plex handler MUST do the same — without it (a) the Job UI's
+        # source chip shows generic "plex" instead of "Plex-B", (b) the
+        # dedup key ``(source, server_id, canonical_path)`` collapses
+        # Plex-A and Plex-B events for the same path on the 60s window,
+        # silently dropping the second one, and (c) the orchestrator gate
+        # (`enabled_plex_count >= 2`) routes to multi-server fan-out with
+        # no pin so the path gets processed against BOTH Plex servers
+        # instead of just Plex-B. The HIGH finding from the architecture
+        # review on issue #244 part 2.
+        mock_schedule.assert_called()
+        sched_kwargs = mock_schedule.call_args.kwargs
+        assert sched_kwargs.get("server_id") == "plex-b", (
+            f"dispatch must receive server_id='plex-b' so the Job is "
+            f"pinned to the originating Plex; got kwargs={sched_kwargs!r}"
+        )
+
+    def test_unknown_uuid_falls_back_to_no_pin(self, client, two_plex_servers):
+        """A payload whose ``Server.uuid`` matches no configured Plex
+        must NOT crash and must NOT silently pin to media_servers[0].
+        Falls back to ``server_id=None`` — the resolver then projects
+        from the first enabled Plex (pre-fix behaviour, acceptable
+        because there is no better signal to use)."""
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-ghost"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test Movie"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload)
+
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.kwargs.get("server_id") is None, (
+            f"unknown uuid must yield server_id=None (fall back, don't pin to "
+            f"media_servers[0]), got {mock_resolve.call_args.kwargs!r}"
+        )
+
+    def test_disabled_pin_falls_through_with_warning(self, client, caplog):
+        """A ``?server_id=`` pin pointing at a DISABLED Plex must not
+        be silently honoured — ``derive_legacy_plex_view`` would then
+        fail to match and return the first enabled Plex's view, the
+        exact first-Plex ghost this fix exists to eliminate. The pin
+        must be rejected and the resolver must fall through to
+        payload-uuid matching (which here finds the enabled Plex)."""
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().set(
+            "media_servers",
+            [
+                {
+                    "id": "plex-a",
+                    "type": "plex",
+                    "enabled": True,
+                    "server_identity": "mid-a",
+                    "url": "http://plex-a:32400",
+                    "auth": {"token": "tok-a"},
+                },
+                {
+                    "id": "plex-b-disabled",
+                    "type": "plex",
+                    "enabled": False,
+                    "server_identity": "mid-b",
+                    "url": "http://plex-b:32400",
+                    "auth": {"token": "tok-b"},
+                },
+            ],
+        )
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-a"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload, query="?server_id=plex-b-disabled")
+
+        assert resp.status_code == 202
+        # Pin rejected → payload-uuid path took over → plex-a chosen.
+        assert mock_resolve.call_args.kwargs.get("server_id") == "plex-a", (
+            f"disabled pin must NOT be honoured; payload uuid should win, got {mock_resolve.call_args.kwargs!r}"
+        )
+
+    def test_non_plex_pin_falls_through_with_warning(self, client):
+        """``?server_id=`` pointing at an Emby/Jellyfin entry by mistake
+        must not be accepted. Same first-Plex-ghost concern as the
+        disabled case."""
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().set(
+            "media_servers",
+            [
+                {
+                    "id": "plex-a",
+                    "type": "plex",
+                    "enabled": True,
+                    "server_identity": "mid-a",
+                    "url": "http://plex-a:32400",
+                    "auth": {"token": "tok-a"},
+                },
+                {"id": "emby-1", "type": "emby", "enabled": True, "url": "http://emby:8096"},
+            ],
+        )
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-a"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload, query="?server_id=emby-1")
+
+        assert resp.status_code == 202
+        assert mock_resolve.call_args.kwargs.get("server_id") == "plex-a", (
+            f"emby pin must NOT route the Plex webhook to emby; payload uuid should win, "
+            f"got {mock_resolve.call_args.kwargs!r}"
+        )
+
+    def test_identity_collision_warns_and_falls_back(self, client, caplog):
+        """Two Plex servers sharing the same machineIdentifier (cloned-
+        VM edge case) — the resolver can't pick one, logs a warning,
+        and returns None so the downstream lookup falls back to
+        media_servers[0]'s view. Pin the warning fires so an operator
+        can spot the collision in their logs."""
+        import logging as _std_logging
+
+        from loguru import logger as _loguru_logger
+
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        get_settings_manager().set(
+            "media_servers",
+            [
+                {
+                    "id": "plex-a",
+                    "type": "plex",
+                    "enabled": True,
+                    "server_identity": "mid-shared",
+                    "url": "http://plex-a:32400",
+                    "auth": {"token": "tok-a"},
+                },
+                {
+                    "id": "plex-b",
+                    "type": "plex",
+                    "enabled": True,
+                    "server_identity": "mid-shared",
+                    "url": "http://plex-b:32400",
+                    "auth": {"token": "tok-b"},
+                },
+            ],
+        )
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-shared"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        # Bridge loguru → caplog so the warning is asserted.
+        records: list = []
+        handler_id = _loguru_logger.add(
+            lambda msg: records.append(
+                _std_logging.LogRecord(
+                    name="loguru",
+                    level=_std_logging.WARNING,
+                    pathname="",
+                    lineno=0,
+                    msg=msg.record["message"],
+                    args=(),
+                    exc_info=None,
+                )
+            ),
+            level="WARNING",
+        )
+        try:
+            with (
+                patch(
+                    "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                    return_value=(["/data/movies/Foo.mkv"], "Test"),
+                ) as mock_resolve,
+                patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+            ):
+                resp = _multipart_post(client, payload)
+        finally:
+            _loguru_logger.remove(handler_id)
+
+        assert resp.status_code == 202
+        assert mock_resolve.call_args.kwargs.get("server_id") is None, (
+            f"identity collision must yield server_id=None (refuse-to-guess), got {mock_resolve.call_args.kwargs!r}"
+        )
+        # The operator's only signal that collision is happening — pin it.
+        warning_text = " ".join(r.msg for r in records)
+        assert "share the same" in warning_text and "machineIdentifier" in warning_text, (
+            f"missing collision warning that tells the operator to fix it; got logs={warning_text!r}"
+        )
+
+    def test_empty_server_uuid_falls_back_to_no_pin(self, client, two_plex_servers):
+        """``{"Server": {"uuid": ""}}`` is "no signal" not "match the
+        empty-string identity". Must yield server_id=None."""
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": ""},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload)
+        assert resp.status_code == 202
+        assert mock_resolve.call_args.kwargs.get("server_id") is None
+
+    def test_missing_server_block_falls_back_to_no_pin(self, client, two_plex_servers):
+        """No ``Server`` key at all in the payload — fall back to None
+        (single-Plex installs sometimes look like this)."""
+        payload = {
+            "event": "library.new",
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload)
+        assert resp.status_code == 202
+        assert mock_resolve.call_args.kwargs.get("server_id") is None
+
+    def test_query_string_server_id_overrides_payload_uuid(self, client, two_plex_servers):
+        """Operator pin: when ``?server_id=plex-b`` is in the URL, it
+        wins over the payload's ``Server.uuid``. Mirrors the Sonarr
+        webhook pattern at webhooks.py:1325 — explicit user intent
+        beats payload heuristics."""
+        payload = {
+            "event": "library.new",
+            "Server": {"title": "Plex", "uuid": "mid-a"},
+            "Metadata": {"ratingKey": "777", "type": "movie", "title": "Test"},
+        }
+
+        with (
+            patch(
+                "media_preview_generator.web.webhooks._resolve_plex_paths_from_rating_key",
+                return_value=(["/data/movies/Foo.mkv"], "Test Movie"),
+            ) as mock_resolve,
+            patch("media_preview_generator.web.webhooks._schedule_webhook_job", return_value=True),
+        ):
+            resp = _multipart_post(client, payload, query="?server_id=plex-b")
+
+        assert resp.status_code == 202, resp.get_data(as_text=True)
+        mock_resolve.assert_called_once()
+        assert mock_resolve.call_args.kwargs.get("server_id") == "plex-b", (
+            f"explicit ?server_id= must override payload uuid, got {mock_resolve.call_args.kwargs!r}"
+        )


### PR DESCRIPTION
## Summary

Closes #244. Two-commit fix for the multi-Plex "scan against the second Plex actually runs against the first" bug.

**Commit 1 — `orchestrator`:** The full-scan gate `_should_use_multi_server_full_scan` returned False for "Plex-only multi-Plex" installs, so dispatch fell through to the legacy `_run_plex_full_scan_phase`, whose enumerator picked the first Plex from `registry.configs()` regardless of `server_id_filter`. Widened the gate so 2+ enabled Plex servers route to the multi-server path that already honours the pin end-to-end. Single-Plex installs unchanged. Defence in depth: legacy enumerator now also filters `c.enabled` so a "[disabled, enabled]" layout can't connect to the disabled one.

**Commit 2 — `webhooks`:** Same shape in the legacy `/api/webhooks/plex` endpoint. When Plex's payload omits inline file paths, the fallback `_resolve_plex_paths_from_rating_key` connected to `media_servers[0]` and silently returned `[]` for ratingKeys owned only by Plex-B. Now resolves the originating Plex from `Server.uuid` → `server_identity` match (with `?server_id=` query override) and threads it through both the ratingKey lookup AND `_schedule_webhook_job` so the Job pin, dedup key, and orchestrator routing all agree. New per-server endpoints (`/api/webhooks/server/<id>`) already worked correctly; this brings the legacy URL up to parity.

## Test plan
- [x] 11 new orchestrator-routing tests (`tests/test_orchestrator_multi_plex_routing.py`)
- [x] 10 new Plex-webhook-routing tests (`tests/test_webhooks_plex_multi_server_routing.py`)
- [x] Full suite green: 3149 passed
- [x] Architecture Review on both diffs: zero HIGH after addressing initial findings
- [ ] Smoke test by issue reporter on `dev` build with two Plex servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)