### PR TITLE
fix(api): hide disabled libraries from /api/libraries picker

### DIFF
--- a/media_preview_generator/web/routes/api_libraries.py
+++ b/media_preview_generator/web/routes/api_libraries.py
@@ -165,6 +165,16 @@ def _libraries_for_configured_server(server_id: str) -> tuple[list[dict] | None,
     rows: list[dict] = []
     try:
         for lib in server.list_libraries():
+            # Disabled libraries can't be scanned (the downstream
+            # enumerator at processing/_shared.py:94 filters them out
+            # via lib.enabled), so showing them in pickers /
+            # dashboards just produces silent "no libraries to scan"
+            # surprises when a user ticks one. The Edit Server modal
+            # uses /api/servers/<id> (which returns the full list with
+            # enabled flags) to toggle them — this endpoint is for
+            # "show me what's actionable."
+            if not lib.enabled:
+                continue
             rows.append(
                 {
                     "id": str(lib.id),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -4061,6 +4061,64 @@ class TestLibrariesAPI:
         token_seen = any(kwargs.get("headers", {}).get("X-Plex-Token") == "test-token" for _, kwargs in captured)
         assert token_seen, f"_fetch_libraries_via_http didn't pass X-Plex-Token; calls: {captured!r}"
 
+    def test_get_libraries_filters_out_disabled_libraries(self, client):
+        """/api/libraries must hide libraries the user has disabled in
+        Settings → Servers → Edit. Pre-fix the endpoint returned every
+        library the live Plex API surfaced, so disabled ones showed up
+        as tickable rows in the Start New Job picker. Ticking one then
+        running the job silently produced "No libraries to scan"
+        because the downstream enumerator (_shared.py:94) filters on
+        ``lib.enabled``. The user expected disabled = hidden everywhere.
+        """
+        from media_preview_generator.servers.base import Library
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        sm = get_settings_manager()
+        sm.set(
+            "media_servers",
+            [
+                {
+                    "id": "plex-test",
+                    "type": "plex",
+                    "name": "Test Plex",
+                    "enabled": True,
+                    "url": "http://plex:32400",
+                    "auth": {"token": "tok"},
+                    "libraries": [
+                        {"id": "1", "name": "Movies", "enabled": True, "kind": "movie"},
+                        {"id": "2", "name": "TV", "enabled": False, "kind": "episode"},
+                        {"id": "3", "name": "Audiobooks", "enabled": False, "kind": "track"},
+                    ],
+                }
+            ],
+        )
+
+        fake_server = MagicMock()
+        fake_server.list_libraries.return_value = [
+            Library(id="1", name="Movies", enabled=True, kind="movie", remote_paths=()),
+            Library(id="2", name="TV", enabled=False, kind="episode", remote_paths=()),
+            Library(id="3", name="Audiobooks", enabled=False, kind="track", remote_paths=()),
+        ]
+        fake_registry = MagicMock()
+        fake_registry.get.return_value = fake_server
+
+        with patch(
+            "media_preview_generator.servers.ServerRegistry.from_settings",
+            return_value=fake_registry,
+        ):
+            resp = client.get("/api/libraries", headers=_api_headers())
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        ids = [lib["id"] for lib in data["libraries"]]
+        # Bug-blind guard: assert the disabled libraries are absent by id,
+        # not just check the count — a future regression that swaps order
+        # or renames libraries silently would pass a length check but
+        # land disabled rows in the picker.
+        assert "1" in ids, f"enabled library 'Movies' (id=1) must be in response; got {ids!r}"
+        assert "2" not in ids, f"disabled library 'TV' (id=2) must be filtered; got {ids!r}"
+        assert "3" not in ids, f"disabled library 'Audiobooks' (id=3) must be filtered; got {ids!r}"
+
     def test_get_libraries_no_config(self, client):
         """Libraries endpoint with no Plex AND no other media servers returns
         empty (multi-server world: 'no config' = no media servers configured,


### PR DESCRIPTION
## Summary

Reporter noticed the Start New Job picker still lists libraries they'd disabled in Settings → Servers → Edit. Ticking one and running the job silently produced "No libraries to scan" because the enumerator at \`processing/_shared.py:94\` correctly filters on \`lib.enabled\` — but the UI had no way to convey that.

Fix: \`_libraries_for_configured_server\` now skips libraries with \`enabled=False\`. The Edit Server modal reads via \`/api/servers/<id>\` (full list) so users can still re-enable.

## Test plan
- [x] New unit test in \`TestLibrariesAPI\` — asserts disabled libs absent by id, not by count (bug-blind guard)
- [x] All 3 LibrariesAPI tests pass
- [x] Full suite: 3158 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)