### PR TITLE
fix(servers): Emby API Key auth missing from picker (#247)

### DIFF
--- a/media_preview_generator/web/static/js/servers.js
+++ b/media_preview_generator/web/static/js/servers.js
@@ -695,9 +695,15 @@
             $$('input[name="authMethod"]').forEach((r) => {
                 r.checked = r.value === defaultMethod;
             });
-            // Quick Connect only makes sense on Jellyfin.
-            $('#auth-quick').parentElement.classList.toggle('d-none', type !== 'jellyfin');
-            $$('label[for=auth-quick]').forEach((l) => l.classList.toggle('d-none', type !== 'jellyfin'));
+            // Quick Connect only makes sense on Jellyfin — hide just
+            // its radio + its label, NOT the parent .btn-group.
+            // Issue #247: the previous ``.parentElement`` toggle hid
+            // the WHOLE auth-method picker (Quick Connect + Password +
+            // API Key) for Emby, leaving the user stuck on the default
+            // Password method with no way to reach API Key.
+            const hideQuick = type !== 'jellyfin';
+            $('#auth-quick').classList.toggle('d-none', hideQuick);
+            $$('label[for=auth-quick]').forEach((l) => l.classList.toggle('d-none', hideQuick));
             renderAuthFields();
         }
     }

--- a/tests/e2e/test_servers_page.py
+++ b/tests/e2e/test_servers_page.py
@@ -99,6 +99,16 @@ class TestAddServerModal:
         expect(servers_page.locator("#step-connect")).to_be_visible(timeout=2000)
         # Emby supports password + api_key auth, so the picker is shown.
         expect(servers_page.locator("#auth-method-section")).to_be_visible(timeout=1000)
+        # Issue #247 regression: configureAuthForType used to call
+        # ``$('#auth-quick').parentElement.classList.toggle('d-none', …)``
+        # which targeted the ENTIRE .btn-group containing all three
+        # auth-method radios. On Emby it hid the whole picker so the
+        # user was stuck on Password with no way to reach API Key.
+        # Pin that the API Key label is reachable for Emby.
+        expect(servers_page.locator('label[for="auth-key"]')).to_be_visible(timeout=1000)
+        expect(servers_page.locator('label[for="auth-pw"]')).to_be_visible(timeout=1000)
+        # And Quick Connect is hidden for Emby (Jellyfin-only feature).
+        expect(servers_page.locator('label[for="auth-quick"]')).to_be_hidden()
 
     def test_picking_jellyfin_shows_auth_method_picker(self, servers_page: Page):
         _force_open_wizard(servers_page)


### PR DESCRIPTION
## Summary

Closes #247. When picking Emby in the setup wizard (or Add Server modal), the auth-method picker showed only Password — no way to switch to API Key.

Root cause: \`servers.js:699\` toggled \`d-none\` on \`$('#auth-quick').parentElement\` to hide Quick Connect for non-Jellyfin. The parent is the entire \`.btn-group\` containing all three method buttons, so hiding it hid the whole picker. Emby users were stuck on the default \`password\` method.

Fix: hide the Quick Connect radio + its label directly, not the parent group.

## Test plan
- [x] Existing \`test_picking_emby_shows_auth_method_picker\` extended to assert each auth-method label's visibility individually — fails on old code, passes on fix
- [x] 16/16 servers e2e pass (Plex / Emby / Jellyfin flows all confirmed)
- [x] Full Python suite: 3158 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)