### PR TITLE
fix(servers): reject URL without scheme in Add Server validation (#247)

### DIFF
--- a/media_preview_generator/web/routes/api_servers.py
+++ b/media_preview_generator/web/routes/api_servers.py
@@ -13,6 +13,7 @@ import os
 import re
 import uuid
 from typing import Any
+from urllib.parse import urlparse
 
 from flask import jsonify, request
 from loguru import logger
@@ -321,6 +322,19 @@ def _validate_server_payload(
     url = str(data.get("url") or base.get("url") or "").strip()
     if not url:
         return None, "url is required"
+    # Issue #247 follow-up: a bare hostname like ``EmbyTest4`` (or
+    # ``localhost:8096`` — urlparse reads ``localhost`` as the scheme)
+    # used to slip through and surface the raw ``requests`` error
+    # "Invalid URL '<host>/System/Info': No scheme supplied" deep in
+    # the Emby/Jellyfin probe. ``api_plex.py``'s legacy endpoint catches
+    # this for Plex; doing it here covers create/update/test-connection
+    # for every vendor uniformly.
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return None, (
+            f"Invalid URL {url!r}. Include the scheme and host, "
+            "e.g. http://emby:8096 or https://plex.example.com:32400."
+        )
 
     auth_in = data.get("auth")
     if is_update and auth_in is not None:

--- a/tests/test_api_servers.py
+++ b/tests/test_api_servers.py
@@ -1110,6 +1110,43 @@ class TestTestConnection:
         assert response.status_code == 400
         assert response.get_json()["ok"] is False
 
+    def test_url_without_scheme_is_rejected_with_friendly_error(self, client, auth_headers):
+        """Issue #247 follow-up: typing a bare hostname like ``EmbyTest4``
+        into the Add-Server URL field used to bubble up the raw
+        ``requests`` error ``"Invalid URL 'EmbyTest4/System/Info': No
+        scheme supplied"`` because ``_validate_server_payload`` only
+        checked that ``url`` was non-empty.
+
+        Plex's legacy ``/api/plex/test-connection`` already rejected this
+        with a friendly hint (see ``api_plex.py``); the generic vendor-
+        agnostic ``/api/servers/test-connection`` did not, so Emby +
+        Jellyfin users got the raw exception. Pinning the hint and 400
+        so future refactors can't silently drop the validation.
+
+        Bug-blindness guard: asserts the response message names BOTH
+        the bad URL and the example scheme, not just ``response.status_code
+        == 400`` — a regression that returned 400 for a different reason
+        (e.g. missing name) would pass a status-only check.
+        """
+        for vendor, bad_url in (("emby", "EmbyTest4"), ("jellyfin", "jf-host:8096"), ("plex", "plex.local")):
+            response = client.post(
+                "/api/servers/test-connection",
+                headers=auth_headers,
+                json={
+                    "type": vendor,
+                    "name": "T",
+                    "url": bad_url,
+                    "auth": {"method": "api_key", "api_key": "k"},
+                },
+            )
+            assert response.status_code == 400, f"{vendor}: expected 400, got {response.status_code}"
+            body = response.get_json()
+            assert body["ok"] is False
+            assert bad_url in body["message"], f"{vendor}: message should quote the bad URL, got {body['message']!r}"
+            assert "http://" in body["message"], (
+                f"{vendor}: message should show the scheme example, got {body['message']!r}"
+            )
+
 
 class TestOutputStatus:
     def _seed_emby(self, *, libraries=None):


### PR DESCRIPTION
## Summary

Follow-up bug surfaced on #247 after PR #251 restored the Emby API Key auth option. Typing a bare hostname like `EmbyTest4` (no scheme) into the Add Server URL field produced the raw `requests` error:

> `Connection test failed: Invalid URL 'EmbyTest4/System/Info': No scheme supplied. Perhaps you meant https://EmbyTest4/System/Info?`

Plex's legacy `/api/plex/test-connection` endpoint already caught this with a friendly hint (via `except MissingSchema` in `api_plex.py:429`), but the generic vendor-agnostic `/api/servers/test-connection` — plus the create/update flows that share `_validate_server_payload` — did not. Emby + Jellyfin users hit the raw exception.

## Root cause

`_validate_server_payload` (`api_servers.py:321`) only checked `url` was non-empty. Empty-scheme URLs flowed all the way down to `_embyish.py:202` (`url = f\"{self._config.url.rstrip('/')}{path}\"` → `EmbyTest4/System/Info`) where `requests` rejected them.

## Fix

One-line `urlparse` check in `_validate_server_payload`: scheme must be `http`/`https` and `netloc` must be non-empty. Returns the same 400 + friendly hint shape as other validation failures.

Also covers `host:port` (which urlparse reads as `scheme=host` with empty netloc — a tricky shape that a naive scheme-only check would miss).

All three URL-accepting endpoints (`POST /api/servers`, `PUT/PATCH /api/servers/<id>`, `POST /api/servers/test-connection`) funnel through `_validate_server_payload`. The per-server `/api/servers/<id>/test-connection` reads from the persisted entry, which is validated at write time — no bypass.

## Test plan

- [x] New `test_url_without_scheme_is_rejected_with_friendly_error` — exercises Plex / Emby / Jellyfin with bare hostname, `host:port`, and dotted-host. Asserts 400, message names the offending URL, message contains `http://` example. Fails on `dev`, passes with fix.
- [x] Full test suite: **3159 passed** locally.
- [x] `ruff check` + `ruff format --check` pass.
- [x] Architecture Review agent run on staged diff — no findings (clean against the eight production bug-shapes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)