### PR TITLE
Unify scan + webhook dispatch onto one engine (#243)

### DIFF
--- a/docs/guides.md
+++ b/docs/guides.md
@@ -127,6 +127,25 @@ content that never decodes on the GPU, set **CPU Workers > 0** so that
 content routes directly to dedicated CPU workers from the main queue
 instead of blocking a GPU worker each time.
 
+#### Speeding up full-library scans on big libraries
+
+A full scan first sweeps every file to check whether a fresh preview
+already exists, then only generates the missing ones. Those two jobs have
+independent concurrency:
+
+- **GPU Workers / CPU Workers** cap how many previews *generate* at once
+  (heavy FFmpeg/GPU work) — keep these matched to your hardware.
+- **Library Scanning → Files checked at once** (`scan_workers`) caps how
+  many files the *existence check* sweeps in parallel. This is light disk
+  I/O and adds no FFmpeg/GPU load.
+
+On a large, mostly-complete library the sweep can dominate. Leave
+**Files checked at once** on **Auto** for most setups; raise it if the
+"checking" phase feels slow on fast storage, or lower it if a single
+spinning HDD thrashes under many parallel stats. Raising it never spawns
+more simultaneous FFmpeg processes — that's still governed by your worker
+counts.
+
 Settings are saved to `/config/settings.json` and persist across restarts.
 
 ### Automation Page

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -115,6 +115,7 @@ GPU settings are configured per-GPU in **Settings** → **Processing Options**. 
 | Setting | Web UI | Default | Description |
 |---------|--------|---------|-------------|
 | `cpu_threads` | Yes | `1` | Number of CPU worker threads (0–32) |
+| `scan_workers` | Yes | `0` (Auto) | Full-scan only: how many files are checked **in parallel** for an existing preview, independent of the FFmpeg-generation cap (GPU + CPU workers). Checking is light disk I/O and does NOT add FFmpeg/GPU load. `0` = Auto (`max(32, generators)`); an explicit value is bounded to 1–256. Raise it to speed the "skip already-done files" sweep on large libraries; lower it on a single spinning HDD. |
 | `thumbnail_quality` | Yes | `4` | Preview quality 1-10 (2=highest) |
 | `thumbnail_interval` | Yes | `10` | Interval between preview images (1–60 s). Matches Plex/BIF community convention (see sidecar `-{width}-10.bif` files). |
 | `selected_libraries` | Yes | All | Library IDs to process |
@@ -205,7 +206,7 @@ These env vars are deprecated and silently ignored at startup with a warning log
 On first run, these env vars are migrated into settings.json. After that, settings.json is the source of truth:
 
 - `PLEX_URL`, `PLEX_TOKEN`, `PLEX_CONFIG_FOLDER`, `PLEX_VERIFY_SSL`, `PLEX_TIMEOUT`
-- `PLEX_BIF_FRAME_INTERVAL` / `THUMBNAIL_INTERVAL` (alias), `THUMBNAIL_QUALITY`, `TONEMAP_ALGORITHM`, `CPU_THREADS`
+- `PLEX_BIF_FRAME_INTERVAL` / `THUMBNAIL_INTERVAL` (alias), `THUMBNAIL_QUALITY`, `TONEMAP_ALGORITHM`, `CPU_THREADS`, `SCAN_WORKERS`
 - `MEDIA_PATH`, `TMP_FOLDER`, `LOG_LEVEL`
 
 ---

--- a/media_preview_generator/config/__init__.py
+++ b/media_preview_generator/config/__init__.py
@@ -147,6 +147,14 @@ class Config:
     # device, name, type, enabled, workers, ffmpeg_threads
     gpu_config: list[dict[str, Any]] = field(default_factory=list)
 
+    # Library-scanning concurrency for full scans: how many items the
+    # high-throughput "does a fresh preview already exist?" sweep checks in
+    # parallel, independent of the FFmpeg-generation cap (gpu_config workers +
+    # cpu_threads). 0 = Auto (the orchestrator resolves it to max(32,
+    # generators)). Checking is light disk I/O; raising it does NOT increase
+    # FFmpeg load. See issue #243.
+    scan_workers: int = 0
+
     # Runtime state (set after construction)
     working_tmp_folder: str = ""
 
@@ -575,6 +583,15 @@ def load_config(*, log_validation_errors: bool = True) -> Config:
 
     cpu_threads = get_value("cpu_threads", "CPU_THREADS", 1, int)
 
+    # Library-scanning concurrency. 0 = Auto (resolved by the orchestrator).
+    # A positive value is clamped to [1, 256] so a typo can't spawn an absurd
+    # thread pool; a negative/garbage value falls back to Auto.
+    scan_workers = get_value("scan_workers", "SCAN_WORKERS", 0, int)
+    if scan_workers < 0:
+        scan_workers = 0
+    elif scan_workers > 256:
+        scan_workers = 256
+
     tmp_folder = get_value("tmp_folder", "TMP_FOLDER", tempfile.gettempdir(), str)
 
     log_level = get_value("log_level", "LOG_LEVEL", "INFO", str).upper()
@@ -732,6 +749,7 @@ def load_config(*, log_validation_errors: bool = True) -> Config:
         cpu_threads=cpu_threads,
         ffmpeg_threads=ffmpeg_threads,
         gpu_config=gpu_config,
+        scan_workers=scan_workers,
         tmp_folder=tmp_folder,
         tmp_folder_created_by_us=tmp_folder_created_by_us,
         ffmpeg_path=ffmpeg_path,

--- a/media_preview_generator/jobs/dispatcher.py
+++ b/media_preview_generator/jobs/dispatcher.py
@@ -93,6 +93,11 @@ class JobTracker:
         # Active Jobs and History sections to grow unbounded on big runs.
         self.publishers_aggregate: dict[str, dict] = {}
         self.done_event = threading.Event()
+        # Flips True the first time one of this job's items is assigned to a
+        # generation worker (set in JobDispatcher._assign_tasks). Drives the
+        # "Checking existing previews…" → "completed" progress label so a
+        # scan that's still sweeping doesn't read as if it's generating.
+        self.generation_started = False
         # Guards every mutation of successful / failed / outcome_counts /
         # publishers_aggregate. Pre-#243 these were only ever touched by the
         # single dispatch-loop thread; the checking stage now folds outcomes
@@ -163,28 +168,46 @@ class JobTracker:
                 self.failed += 1
             is_done = (self.successful + self.failed) >= self.total_items
 
-        if self.on_item_complete:
-            self.on_item_complete(worker_display_name, title, success)
+        # A raising callback must never prevent done_event.set() below — that
+        # would strand the job (hang). It also runs in the shared dispatch loop
+        # thread (via _check_completions), so an unguarded raise there kills
+        # the loop for every job. Swallow + log; completion always proceeds.
+        try:
+            if self.on_item_complete:
+                self.on_item_complete(worker_display_name, title, success)
 
-        if self.progress_callback:
-            now = time.time()
-            is_final = is_done
-            if is_final or now - self._last_progress_update >= 0.5:
-                fraction = 0.0
-                if self.in_progress_fraction_getter is not None:
-                    try:
-                        fraction = self.in_progress_fraction_getter()
-                    except Exception:
-                        fraction = 0.0
-                effective = self.completed + fraction
-                percent = (effective / self.total_items * 100) if self.total_items > 0 else 0
-                self.progress_callback(
-                    self.completed,
-                    self.total_items,
-                    f"{self.library_prefix}{self.completed}/{self.total_items} completed",
-                    percent_override=percent,
-                )
-                self._last_progress_update = now
+            if self.progress_callback:
+                now = time.time()
+                is_final = is_done
+                if is_final or now - self._last_progress_update >= 0.5:
+                    fraction = 0.0
+                    if self.in_progress_fraction_getter is not None:
+                        try:
+                            fraction = self.in_progress_fraction_getter()
+                        except Exception:
+                            fraction = 0.0
+                    effective = self.completed + fraction
+                    percent = (effective / self.total_items * 100) if self.total_items > 0 else 0
+                    # Until the first item claims a generation worker, the job
+                    # is still sweeping the library for existing previews —
+                    # surface that rather than "completed", which reads as
+                    # generation. Flips to the normal label the moment
+                    # generation begins (set in JobDispatcher._assign_tasks).
+                    # Mirrors the label the multi-server scan path showed
+                    # before the engines merged.
+                    if self.generation_started:
+                        msg = f"{self.library_prefix}{self.completed}/{self.total_items} completed"
+                    else:
+                        msg = f"{self.library_prefix}Checking existing previews… {self.completed}/{self.total_items}"
+                    self.progress_callback(
+                        self.completed,
+                        self.total_items,
+                        msg,
+                        percent_override=percent,
+                    )
+                    self._last_progress_update = now
+        except Exception as exc:
+            logger.debug("Job {} completion callback raised (ignored): {}", self.job_id, exc)
 
         if is_done:
             self.done_event.set()
@@ -237,16 +260,28 @@ class JobTracker:
         # NO_MEDIA_PARTS / SKIPPED_FILE_NOT_FOUND / pending all count as done.
         success = outcome is not ProcessingResult.FAILED
 
-        rows = _publisher_rows_from_result(result, getattr(result, "canonical_path", "") or item.canonical_path)
+        # Publisher rows are best-effort UI attribution — never let a malformed
+        # result block the count/completion below.
+        try:
+            rows = _publisher_rows_from_result(result, getattr(result, "canonical_path", "") or item.canonical_path)
+        except Exception as exc:
+            logger.debug("Could not build publisher rows for {}: {}", item.canonical_path, exc)
+            rows = []
         # Counter + aggregate mutations under the lock (concurrent check threads).
+        # The aggregate fold is guarded *inside* the lock so a raise there can't
+        # propagate to _run_check's router AFTER the outcome counter has already
+        # been bumped — that double-counts the item (re-queue → worker counts it
+        # again), the exact "X processed / Y in outcome" divergence shape.
         with self._counts_lock:
             if outcome.value in self.outcome_counts:
                 self.outcome_counts[outcome.value] += 1
+            publishers_snapshot = None
             if rows:
-                fold_publisher_rows_into_aggregate(self.publishers_aggregate, rows)
-                publishers_snapshot = list(self.publishers_aggregate.values())
-            else:
-                publishers_snapshot = None
+                try:
+                    fold_publisher_rows_into_aggregate(self.publishers_aggregate, rows)
+                    publishers_snapshot = list(self.publishers_aggregate.values())
+                except Exception as exc:
+                    logger.debug("Could not fold publisher rows for {}: {}", item.canonical_path, exc)
         if publishers_snapshot is not None:
             try:
                 from ..web.jobs import get_job_manager
@@ -260,14 +295,14 @@ class JobTracker:
                 getattr(result, "canonical_path", "") or item.canonical_path,
                 outcome,
                 (getattr(result, "message", "") or "").strip(),
-                "Checking",
+                "Library scan",
                 servers=rows,
             )
         except Exception as exc:
             logger.debug("Could not notify checked file result for {}: {}", item.canonical_path, exc)
 
         title = getattr(item, "title", "") or item.canonical_path
-        self.record_completion(success, "Checking", title)
+        self.record_completion(success, "Library scan", title)
 
     def wait(self, timeout: float | None = None) -> bool:
         """Block until all items are processed.
@@ -466,39 +501,49 @@ class JobDispatcher:
             if self._shutdown:
                 break
 
-            # 1. Handle cancelled jobs
-            self._handle_cancellations()
+            # The whole iteration is guarded: this is the SHARED loop for every
+            # job, so an unhandled exception in any step (a raising callback,
+            # malformed worker state, a transient error) must not kill it —
+            # that would hang every active and future job. Log and continue;
+            # the next tick retries. Per-item failures are already isolated in
+            # the worker/check threads, so this only catches engine-level slips.
+            try:
+                # 1. Handle cancelled jobs
+                self._handle_cancellations()
 
-            # 2. Check worker completions and route to trackers
-            self._check_completions()
+                # 2. Check worker completions and route to trackers
+                self._check_completions()
 
-            # 2b. Feed the checking stage: sweep unchecked items (bounded,
-            #     priority-aware). Already-fresh items are recorded here and
-            #     never reach a processing worker; items needing FFmpeg land
-            #     in the per-job item_queue that step 3 drains.
-            self._submit_checks()
+                # 2b. Feed the checking stage: sweep unchecked items (bounded,
+                #     priority-aware). Already-fresh items are recorded here and
+                #     never reach a processing worker; items needing FFmpeg land
+                #     in the per-job item_queue that step 3 drains.
+                self._submit_checks()
 
-            # 3. Assign items to available workers BEFORE emitting
-            #    updates so the first status emission reflects the newly
-            #    busy worker instead of stale "idle" data.
-            self._assign_tasks()
+                # 3. Assign items to available workers BEFORE emitting
+                #    updates so the first status emission reflects the newly
+                #    busy worker instead of stale "idle" data.
+                self._assign_tasks()
 
-            # 4. Emit periodic worker status updates for all active jobs
-            self._emit_worker_updates()
+                # 4. Emit periodic worker status updates for all active jobs
+                self._emit_worker_updates()
 
-            # 5. Emit periodic progress updates for active jobs
-            self._emit_progress_updates()
+                # 5. Emit periodic progress updates for active jobs
+                self._emit_progress_updates()
 
-            # 6. Periodic progress logging
-            now = time.time()
-            if now - last_progress_log >= 5.0:
-                self._log_progress()
-                last_progress_log = now
+                # 6. Periodic progress logging
+                now = time.time()
+                if now - last_progress_log >= 5.0:
+                    self._log_progress()
+                    last_progress_log = now
 
-            # 7. Clean up completed trackers and check if loop can idle
-            self._cleanup_done_trackers()
-            if self._all_idle():
-                self._has_work.clear()
+                # 7. Clean up completed trackers and check if loop can idle
+                self._cleanup_done_trackers()
+                if self._all_idle():
+                    self._has_work.clear()
+            except Exception:
+                logger.exception("Dispatcher: dispatch loop iteration failed; continuing")
+                time.sleep(0.05)
 
             # Event-based sleep: wake immediately when any worker
             # completes instead of burning a fixed 5 ms.  Falls back
@@ -638,6 +683,10 @@ class JobDispatcher:
                 worker.is_busy = False
                 continue
 
+            # First item of this job to reach a generation worker — flip the
+            # progress label off "Checking existing previews…".
+            tracker.generation_started = True
+
             progress_callback = partial(self.worker_pool._update_worker_progress, worker)
             worker.assign_task(
                 item,
@@ -770,12 +819,23 @@ class JobDispatcher:
                     regenerate=bool(getattr(tracker.config, "regenerate_thumbnails", False)),
                     check_only=True,
                 )
+
+                if result.status is MultiServerStatus.NEEDS_GENERATION:
+                    # Guard: never re-queue into a job cancel() already drained.
+                    if not tracker.is_cancelled() and not tracker.done_event.is_set():
+                        tracker.item_queue.append(item)
+                elif not tracker.done_event.is_set():
+                    tracker.record_check_result(item, result)
             except Exception as exc:
-                # The cheap check raised — route to a processing worker so the
-                # full path's error handling / CPU fallback / retries apply (the
-                # same conservative fallthrough the orchestrator uses). Guarded
-                # so a job cancelled mid-check doesn't re-populate a drained
-                # queue (cancel() force-completes; re-queuing would strand it).
+                # ANYTHING the check stage raises — the cheap probe itself, an
+                # unexpected/malformed result (e.g. no .status), or recording —
+                # routes the item to a processing worker so the full path's
+                # error handling / CPU fallback / retries apply (the same
+                # conservative fallthrough the orchestrator uses). Crucially
+                # this also means the item always *completes*: stranding it
+                # here (the routing used to sit outside this guard) left
+                # tracker.wait() blocking forever. Guarded so a job cancelled
+                # mid-check doesn't re-populate a queue cancel() already drained.
                 logger.debug(
                     "Dispatcher: check raised for {!r} ({}: {}); routing to a processing worker.",
                     item.canonical_path,
@@ -785,13 +845,6 @@ class JobDispatcher:
                 if not tracker.is_cancelled() and not tracker.done_event.is_set():
                     tracker.item_queue.append(item)
                 return
-
-            if result.status is MultiServerStatus.NEEDS_GENERATION:
-                # Same guard: never re-queue into a job cancel() already drained.
-                if not tracker.is_cancelled() and not tracker.done_event.is_set():
-                    tracker.item_queue.append(item)
-            elif not tracker.done_event.is_set():
-                tracker.record_check_result(item, result)
 
     def update_job_priority(self, job_id: str, priority: int) -> None:
         """Update the dispatch priority of a running job's tracker.

--- a/media_preview_generator/jobs/dispatcher.py
+++ b/media_preview_generator/jobs/dispatcher.py
@@ -70,7 +70,17 @@ class JobTracker:
         self.library_name = library_name
         self.library_prefix = f"[{library_name}] " if library_name else ""
 
-        self.item_queue: deque = deque(items)
+        # Two-stage queues (issue #243 unification). Every submitted item
+        # first lands in ``check_queue``, where the dispatcher's checking
+        # workers run the cheap ``process_canonical_path(check_only=True)``
+        # pass. Items already fresh (or otherwise terminal) are recorded
+        # straight away via ``record_check_result`` and never touch a
+        # GPU/CPU processing worker. Items that genuinely need FFmpeg are
+        # appended to ``item_queue``, which the processing workers drain
+        # exactly as before. ``total_items`` counts every submitted item;
+        # each one is recorded exactly once (check-skip OR processing).
+        self.check_queue: deque = deque(items)
+        self.item_queue: deque = deque()
         self.total_items = len(items)
         self.successful = 0
         self.failed = 0
@@ -83,6 +93,14 @@ class JobTracker:
         # Active Jobs and History sections to grow unbounded on big runs.
         self.publishers_aggregate: dict[str, dict] = {}
         self.done_event = threading.Event()
+        # Guards every mutation of successful / failed / outcome_counts /
+        # publishers_aggregate. Pre-#243 these were only ever touched by the
+        # single dispatch-loop thread; the checking stage now folds outcomes
+        # from up to ``scan_workers`` concurrent daemon check threads AND the
+        # dispatch loop concurrently folds finished FFmpeg items — non-atomic
+        # ``+=`` would lose increments, so ``completed`` could never reach
+        # ``total_items`` and ``done_event`` would never fire (hung job).
+        self._counts_lock = threading.Lock()
 
         cbs = callbacks or {}
         self.progress_callback: Callable | None = cbs.get("progress_callback")
@@ -136,17 +154,21 @@ class JobTracker:
             title: Media title for logging.
 
         """
-        if success:
-            self.successful += 1
-        else:
-            self.failed += 1
+        # Increment under the lock and capture the post-increment completion
+        # state atomically (the checking stage calls this from many threads).
+        with self._counts_lock:
+            if success:
+                self.successful += 1
+            else:
+                self.failed += 1
+            is_done = (self.successful + self.failed) >= self.total_items
 
         if self.on_item_complete:
             self.on_item_complete(worker_display_name, title, success)
 
         if self.progress_callback:
             now = time.time()
-            is_final = self.completed >= self.total_items
+            is_final = is_done
             if is_final or now - self._last_progress_update >= 0.5:
                 fraction = 0.0
                 if self.in_progress_fraction_getter is not None:
@@ -164,17 +186,88 @@ class JobTracker:
                 )
                 self._last_progress_update = now
 
-        if self.completed >= self.total_items:
+        if is_done:
             self.done_event.set()
 
     def cancel(self) -> None:
-        """Mark this job cancelled and drain remaining items."""
+        """Mark this job cancelled and drain remaining items.
+
+        Drains BOTH the not-yet-checked queue and the checked-but-not-yet-
+        generated queue so the failed tally covers every still-pending item.
+        """
         self.cancelled = True
-        remaining = len(self.item_queue)
-        self.item_queue.clear()
-        if remaining:
-            self.failed += remaining
+        with self._counts_lock:
+            remaining = len(self.check_queue) + len(self.item_queue)
+            self.check_queue.clear()
+            self.item_queue.clear()
+            if remaining:
+                self.failed += remaining
         self.done_event.set()
+
+    def record_check_result(self, item, result) -> None:
+        """Record an item decided by the checking stage (no processing worker).
+
+        ``result`` is the :class:`MultiServerResult` from a
+        ``check_only=True`` call whose status is terminal (SKIPPED,
+        PUBLISHED pending-registration, NO_OWNERS, SKIPPED_FILE_NOT_FOUND) —
+        i.e. it did NOT need FFmpeg. Folds the same outcome counts +
+        per-server publisher rows + Files-panel row + completion that
+        ``_merge_worker_outcome`` + ``record_completion`` produce for the
+        processing path (it does NOT call them — it writes the equivalent
+        data inline), so accounting is identical regardless of which stage
+        finished the item. Must run inside ``failure_scope(job_id)`` (the
+        caller, ``_run_check``, provides it) so the Files-panel row routes to
+        this job. No-op if the job is already done (e.g. cancelled mid-check).
+        """
+        if self.done_event.is_set():
+            return
+
+        # Lazy imports avoid a circular import at module load
+        # (orchestrator imports the dispatcher singleton lazily too).
+        from ..processing.generator import _notify_file_result
+        from .orchestrator import (
+            _outcome_for_multi_server_status,
+            _publisher_rows_from_result,
+            fold_publisher_rows_into_aggregate,
+        )
+
+        outcome = _outcome_for_multi_server_status(result.status)
+        # Same coarse success rule the processing path uses
+        # (Worker._process_item): only FAILED counts as a failure; SKIPPED /
+        # NO_MEDIA_PARTS / SKIPPED_FILE_NOT_FOUND / pending all count as done.
+        success = outcome is not ProcessingResult.FAILED
+
+        rows = _publisher_rows_from_result(result, getattr(result, "canonical_path", "") or item.canonical_path)
+        # Counter + aggregate mutations under the lock (concurrent check threads).
+        with self._counts_lock:
+            if outcome.value in self.outcome_counts:
+                self.outcome_counts[outcome.value] += 1
+            if rows:
+                fold_publisher_rows_into_aggregate(self.publishers_aggregate, rows)
+                publishers_snapshot = list(self.publishers_aggregate.values())
+            else:
+                publishers_snapshot = None
+        if publishers_snapshot is not None:
+            try:
+                from ..web.jobs import get_job_manager
+
+                get_job_manager().set_publishers(self.job_id, publishers_snapshot)
+            except Exception as exc:
+                logger.debug("Could not set publisher aggregate for job {}: {}", self.job_id, exc)
+
+        try:
+            _notify_file_result(
+                getattr(result, "canonical_path", "") or item.canonical_path,
+                outcome,
+                (getattr(result, "message", "") or "").strip(),
+                "Checking",
+                servers=rows,
+            )
+        except Exception as exc:
+            logger.debug("Could not notify checked file result for {}: {}", item.canonical_path, exc)
+
+        title = getattr(item, "title", "") or item.canonical_path
+        self.record_completion(success, "Checking", title)
 
     def wait(self, timeout: float | None = None) -> bool:
         """Block until all items are processed.
@@ -229,6 +322,29 @@ class JobDispatcher:
         # don't flicker invisibly).
         self._last_worker_busy_snapshot: dict[int, bool] = {}
 
+        # Checking stage (issue #243): a bounded pool of lightweight
+        # "checking workers" that run process_canonical_path(check_only=True)
+        # on submitted items BEFORE they can claim a (capped) GPU/CPU
+        # processing worker. Decouples the fast "does a fresh preview exist?"
+        # sweep from the heavy FFmpeg cap. Items already fresh are recorded
+        # straight away; only items needing FFmpeg reach the processing pool.
+        #
+        # Driven by the dispatch loop (single priority-aware picker) which
+        # spawns one short-lived **daemon** thread per check, capped at
+        # ``_max_checks`` in flight. Daemon matters: a check that blocks on a
+        # hung mount inside process_canonical_path (the same os.path.isfile
+        # the processing worker hits) must NOT keep the process alive — the
+        # legacy worker threads were daemon for exactly this reason. A
+        # non-daemon pool (e.g. ThreadPoolExecutor) would leave a stuck check
+        # blocking interpreter/xdist-worker shutdown ("not properly
+        # terminated"). On-demand spawn means a 1-item webhook uses 1 thread,
+        # not ``_max_checks``; threads exit when their check returns, so
+        # nothing accumulates.
+        self._max_checks = 0
+        self._checks_in_flight = 0
+        self._checks_in_flight_lock = threading.Lock()
+        self._check_pool_started = False
+
     def submit_items(
         self,
         job_id: str,
@@ -276,9 +392,33 @@ class JobDispatcher:
         logger.info(
             "Dispatcher: submitted {} items for job {} ({})", len(items), job_id[:8], library_name or "no library"
         )
+        self._ensure_check_pool_running(config)
         self._has_work.set()
         self._ensure_dispatch_running()
         return tracker
+
+    def _resolve_scan_workers(self, config: Config) -> int:
+        """Resolve the checking-pool size from config.
+
+        ``scan_workers`` 0 = Auto → ``max(32, processing workers)``, mirroring
+        the orchestrator's resolution so the default lands at the same value
+        regardless of which path created the dispatcher. An explicit value is
+        floored at 1.
+        """
+        try:
+            cfg = max(0, int(getattr(config, "scan_workers", 0) or 0))
+        except (TypeError, ValueError):
+            cfg = 0
+        generators = max(1, len(self.worker_pool._snapshot_workers()))
+        return cfg if cfg > 0 else max(32, generators)
+
+    def _ensure_check_pool_running(self, config: Config) -> None:
+        """Set the checking in-flight cap once, sized from ``scan_workers``."""
+        if self._check_pool_started:
+            return
+        self._max_checks = self._resolve_scan_workers(config)
+        self._check_pool_started = True
+        logger.info("Dispatcher: checking enabled ({} max in-flight)", self._max_checks)
 
     def cancel_job(self, job_id: str) -> None:
         """Cancel a job's remaining items in the dispatch queue."""
@@ -289,11 +429,12 @@ class JobDispatcher:
             logger.info("Dispatcher: cancelled job {}", job_id[:8])
 
     def shutdown(self) -> None:
-        """Stop the dispatch loop and shut down the worker pool."""
+        """Stop the dispatch loop + checking executor and shut down the pool."""
         self._shutdown = True
-        self._has_work.set()  # Wake the loop so it can exit
+        self._has_work.set()  # Wake the dispatch loop so it can exit
         if self._dispatch_thread and self._dispatch_thread.is_alive():
             self._dispatch_thread.join(timeout=30)
+        # Checking threads are daemon + short-lived — no executor to drain.
         self.worker_pool.shutdown()
 
     # ------------------------------------------------------------------
@@ -330,6 +471,12 @@ class JobDispatcher:
 
             # 2. Check worker completions and route to trackers
             self._check_completions()
+
+            # 2b. Feed the checking stage: sweep unchecked items (bounded,
+            #     priority-aware). Already-fresh items are recorded here and
+            #     never reach a processing worker; items needing FFmpeg land
+            #     in the per-job item_queue that step 3 drains.
+            self._submit_checks()
 
             # 3. Assign items to available workers BEFORE emitting
             #    updates so the first status emission reflects the newly
@@ -424,9 +571,13 @@ class JobDispatcher:
         outcome counters changed during the most recent task.
         """
         delta = worker.last_task_outcome_delta()
-        for key, count in delta.items():
-            if count > 0 and key in tracker.outcome_counts:
-                tracker.outcome_counts[key] += count
+        # Under the tracker lock: the checking stage now folds outcome_counts
+        # from concurrent check threads, so this dispatch-loop fold must not
+        # race them (non-atomic ``+=`` would lose increments → hung job).
+        with tracker._counts_lock:
+            for key, count in delta.items():
+                if count > 0 and key in tracker.outcome_counts:
+                    tracker.outcome_counts[key] += count
         # D12 — fold this task's per-server publisher rows into the
         # tracker's per-server aggregate (server_id → status counts) and
         # mirror that fixed-size summary onto the Job. The earlier D7
@@ -442,13 +593,15 @@ class JobDispatcher:
         if worker.last_publishers:
             from .orchestrator import fold_publisher_rows_into_aggregate
 
-            fold_publisher_rows_into_aggregate(tracker.publishers_aggregate, worker.last_publishers)
+            with tracker._counts_lock:
+                fold_publisher_rows_into_aggregate(tracker.publishers_aggregate, worker.last_publishers)
+                publishers_snapshot = list(tracker.publishers_aggregate.values())
             try:
                 from ..web.jobs import get_job_manager
 
                 get_job_manager().set_publishers(
                     tracker.job_id,
-                    list(tracker.publishers_aggregate.values()),
+                    publishers_snapshot,
                 )
             except Exception as exc:
                 logger.debug(
@@ -503,6 +656,142 @@ class JobDispatcher:
                 job_id[:8],
                 worker.display_name,
             )
+
+    def _get_next_check_item(self):
+        """Pick the next item to CHECK, priority-aware, skipping paused jobs.
+
+        Mirrors :meth:`_get_next_item` but drains ``check_queue`` (the
+        pre-FFmpeg checking stage) instead of ``item_queue`` (processing).
+
+        Returns ``(tracker, item)`` or ``None``.
+        """
+        with self._trackers_lock:
+            eligible = [
+                t
+                for t in self._trackers.values()
+                if not t.done_event.is_set() and not t.is_paused() and not t.is_cancelled() and t.check_queue
+            ]
+            eligible.sort(key=lambda t: (t.priority, t.submission_order))
+            for tracker in eligible:
+                item = tracker.check_queue.popleft()
+                return (tracker, item)
+        return None
+
+    def _submit_checks(self) -> None:
+        """Spawn checking tasks as bounded, short-lived daemon threads.
+
+        Called from the dispatch loop. Picks the highest-priority unchecked
+        item and runs it on a fresh daemon thread, up to ``_max_checks`` in
+        flight. Priority-aware (single picker), bounded (in-flight cap),
+        on-demand (one thread per concurrent check; none persist). Daemon so a
+        check stuck on a hung mount can never block process shutdown.
+        """
+        if not self._check_pool_started:
+            return
+        while True:
+            with self._checks_in_flight_lock:
+                if self._checks_in_flight >= self._max_checks:
+                    return
+            picked = self._get_next_check_item()
+            if picked is None:
+                return
+            tracker, item = picked
+            with self._checks_in_flight_lock:
+                self._checks_in_flight += 1
+            threading.Thread(
+                target=self._run_check_and_release,
+                args=(tracker, item),
+                name="job-checker",
+                daemon=True,
+            ).start()
+
+    def _run_check_and_release(self, tracker: JobTracker, item) -> None:
+        """Run one check then release its in-flight slot + wake the loop."""
+        from .worker import unregister_job_thread
+
+        try:
+            self._run_check(tracker, item)
+        finally:
+            # Mirror the processing worker's per-thread cleanup so this
+            # short-lived check thread's ident doesn't linger in the per-job
+            # log-routing map after it exits.
+            unregister_job_thread()
+            self._on_check_done()
+
+    def _on_check_done(self) -> None:
+        with self._checks_in_flight_lock:
+            self._checks_in_flight -= 1
+        # Wake the dispatch loop so it can submit more checks, assign any
+        # newly-queued processing items, and refresh progress/idle state.
+        self._has_work.set()
+        self._worker_done.set()
+
+    def _run_check(self, tracker: JobTracker, item) -> None:
+        """Run one ``check_only`` pass and route the outcome.
+
+        Terminal results (already fresh, no-owners, source-missing,
+        pending-registration) are recorded straight onto the tracker — no
+        GPU/CPU processing worker is claimed. Items needing FFmpeg are
+        appended to the tracker's processing queue. ``check_only=True`` is
+        contractually guaranteed never to run FFmpeg, so generation only
+        happens later under the capped processing workers.
+        """
+        # Re-check cancel/done right before any work so a job cancelled
+        # between pick and run does no I/O.
+        if tracker.is_cancelled() or tracker.done_event.is_set():
+            return
+
+        from ..processing.generator import failure_scope
+        from ..processing.multi_server import MultiServerStatus, process_canonical_path
+        from .worker import register_job_thread, resolve_per_item_pin
+
+        # Register under the job so the per-job log captures the check's
+        # Dispatch / Owners-resolved lines (mirrors the processing worker).
+        register_job_thread(tracker.job_id)
+        per_item_pin = resolve_per_item_pin(tracker.config, item, tracker.registry)
+        # ``failure_scope`` (NOT register_job_thread) is what routes
+        # ``_notify_file_result`` rows + ``record_failure`` to this job — the
+        # processing worker wraps process_canonical_path the same way
+        # (worker.py). Without it, a checked item's Files-panel row + any
+        # failure land in the anonymous "" bucket and are dropped.
+        with failure_scope(tracker.job_id):
+            try:
+                result = process_canonical_path(
+                    canonical_path=item.canonical_path,
+                    registry=tracker.registry,
+                    config=tracker.config,
+                    item_id_by_server=getattr(item, "item_id_by_server", None) or None,
+                    bundle_metadata_by_server=getattr(item, "bundle_metadata_by_server", None) or None,
+                    gpu=None,
+                    gpu_device_path=None,
+                    progress_callback=None,
+                    cancel_check=tracker.cancel_check,
+                    server_id_filter=per_item_pin,
+                    regenerate=bool(getattr(tracker.config, "regenerate_thumbnails", False)),
+                    check_only=True,
+                )
+            except Exception as exc:
+                # The cheap check raised — route to a processing worker so the
+                # full path's error handling / CPU fallback / retries apply (the
+                # same conservative fallthrough the orchestrator uses). Guarded
+                # so a job cancelled mid-check doesn't re-populate a drained
+                # queue (cancel() force-completes; re-queuing would strand it).
+                logger.debug(
+                    "Dispatcher: check raised for {!r} ({}: {}); routing to a processing worker.",
+                    item.canonical_path,
+                    type(exc).__name__,
+                    exc,
+                )
+                if not tracker.is_cancelled() and not tracker.done_event.is_set():
+                    tracker.item_queue.append(item)
+                return
+
+            if result.status is MultiServerStatus.NEEDS_GENERATION:
+                # Same guard: never re-queue into a job cancel() already drained.
+                if not tracker.is_cancelled() and not tracker.done_event.is_set():
+                    tracker.item_queue.append(item)
+            elif not tracker.done_event.is_set():
+                tracker.record_check_result(item, result)
 
     def update_job_priority(self, job_id: str, priority: int) -> None:
         """Update the dispatch priority of a running job's tracker.
@@ -696,6 +985,9 @@ class JobDispatcher:
         """Check if there is no work left (no items, no busy workers)."""
         if self.worker_pool.has_busy_workers():
             return False
+        with self._checks_in_flight_lock:
+            if self._checks_in_flight > 0:
+                return False
         with self._trackers_lock:
             for tracker in self._trackers.values():
                 if not tracker.done_event.is_set():

--- a/media_preview_generator/jobs/orchestrator.py
+++ b/media_preview_generator/jobs/orchestrator.py
@@ -8,7 +8,6 @@ by the web layer (job_runner.py).
 import os
 import random
 import shutil
-import time
 
 from loguru import logger
 
@@ -16,15 +15,9 @@ from ..processing.generator import ProcessingResult, clear_failures, log_failure
 from ..servers.ownership import apply_path_mappings, apply_webhook_prefixes, find_owning_servers
 from .worker import WorkerPool
 
+
 # Max cadence for worker-snapshot SocketIO emits during a multi-server
 # dispatch. See the long comment in ``_dispatch_processable_items`` —
-# 1 Hz matches the legacy ``WorkerPool`` (``worker.py:1245``). Exposed
-# as a module-level constant so tests that observe transient
-# "processing" snapshots can ``monkeypatch.setattr`` it down to a few
-# milliseconds without exercising the production cadence.
-_WORKER_EMIT_THROTTLE_S = 1.0
-
-
 def _resolve_webhook_path_to_canonical(
     path: str, server_configs: list, *, log_resolution: bool = True
 ) -> tuple[str, list]:
@@ -536,966 +529,113 @@ def _dispatch_processable_items(
     server_id_filter: str | None = None,
     worker_callback=None,
     on_dispatch_start=None,
+    worker_pool_callback=None,
 ) -> dict:
-    """Run a list of ``(server_config, ProcessableItem)`` pairs in parallel.
+    """Submit ``(server_config, ProcessableItem)`` pairs to the shared dispatcher.
 
-    Shared dispatch loop used by :func:`_run_full_scan_multi_server` and
-    :func:`_run_recently_added_multi_server`. Pulled out so adding new
-    enumeration sources doesn't mean copying ~80 lines of GPU rotation +
-    progress-callback + per-publisher aggregation.
+    This used to be a second, parallel execution engine (its own
+    ThreadPoolExecutor + slot pool + hot-reload poller). It now feeds the one
+    shared :class:`JobDispatcher` — the same engine webhooks and single-Plex
+    scans use — so there is a SINGLE worker model with the checking/processing
+    split for every trigger and every vendor, and a scan + an incoming webhook
+    share one capped pool instead of oversubscribing two.
 
-    Args:
-        items: Pre-collected list of ``(server_config, ProcessableItem)``.
-        config: Job-wide :class:`Config` used by FFmpeg + frame extraction.
-        registry: Live :class:`ServerRegistry` (publishers fan out via this).
-        selected_gpus: ``[(gpu_type, gpu_device, gpu_info), ...]`` from the
-            UI's GPU selection. Workers use this round-robin.
-        progress_callback: Optional ``(processed, total, msg)`` callback
-            forwarded to the UI's progress widget.
-        cancel_check: Optional callable returning True when the caller wants
-            the dispatch to stop.
-        job_id: Optional job identifier; per-publisher rows get appended to
-            this job for the dashboard's per-server status view.
-        label: Free-text identifier used in info logs ("full scan",
-            "recently-added scan", etc.) so log lines stay grep-friendly.
+    ``items`` is ``[(server_config, ProcessableItem), ...]``; only the
+    ProcessableItem is forwarded — the per-item publish pin is resolved from
+    ``config.server_id_filter`` + ``item.server_id`` inside the worker /
+    checking stage (:func:`jobs.worker.resolve_per_item_pin`), equivalent to
+    the old per-tuple ``server_cfg.type`` logic since ``item.server_id ==
+    server_cfg.id`` for enumerated items. ``server_id_filter`` is accepted for
+    signature compatibility and is already carried on ``config``.
 
-    Returns:
-        Aggregated PublisherStatus counts keyed by enum value
-        (``published``/``failed``/``skipped_*``) — same shape every
-        existing caller already depends on.
+    Returns the tracker's per-file ProcessingResult outcome counts
+    (``generated`` / ``skipped_bif_exists`` / …) — the same per-item scheme the
+    webhook + single-Plex path already produces and every consumer already
+    reads.
     """
-    import threading
-    from concurrent.futures import ThreadPoolExecutor, as_completed
+    import uuid
 
-    from ..processing.generator import (
-        CancellationError,
-        CodecNotSupportedError,
-        _notify_file_result,
-        failure_scope,
-    )
-    from ..processing.multi_server import MultiServerStatus, process_canonical_path
-    from ..servers.base import ServerType
+    from ..web.jobs import PRIORITY_NORMAL
+    from .dispatcher import get_dispatcher
+    from .worker import WorkerPool
 
-    counts = {r.value: 0 for r in ProcessingResult}
-    total = len(items)
-    if total == 0:
-        return counts
+    empty = {r.value: 0 for r in ProcessingResult}
+    plain_items = [item for (_server_cfg, item) in items]
+    total = len(plain_items)
+    if not plain_items:
+        return empty
 
-    gpu_devices = list(selected_gpus or [])
-    cpu_workers = max(0, int(getattr(config, "cpu_threads", 1) or 0))
+    # Reuse the shared dispatcher's pool when one already exists (e.g. a
+    # concurrent webhook created it); otherwise build one sized from the
+    # user's GPU/CPU worker config + selected GPUs (mirrors the legacy
+    # ``_create_worker_pool`` in run_processing).
+    existing = get_dispatcher()
+    if existing is not None:
+        worker_pool = existing.worker_pool
+        logger.info(
+            "Multi-server {}: reusing shared worker pool ({} worker(s))",
+            label,
+            len(worker_pool._snapshot_workers()),
+        )
+    else:
+        sel = list(selected_gpus or [])
+        # ``config.gpu_threads`` can be > 0 while no GPU is actually
+        # selected/detected (a configured GPU that's currently absent), and
+        # WorkerPool raises if asked for GPU workers with no devices. Clamp to
+        # 0 → CPU-only, never crash the whole dispatch. With GPUs present this
+        # is a no-op (in production gpu_threads and selected_gpus both derive
+        # from gpu_config, so they agree).
+        worker_pool = WorkerPool(
+            gpu_workers=int(getattr(config, "gpu_threads", 0) or 0) if sel else 0,
+            cpu_workers=int(getattr(config, "cpu_threads", 0) or 0),
+            selected_gpus=sel,
+        )
+    dispatcher = get_dispatcher(worker_pool)
 
-    def _read_workers_count(gpu_info) -> int:
-        # Previously ``getattr(g[2], "workers", 1)`` — but ``g[2]`` is the
-        # dict that ``_build_selected_gpus`` constructs with
-        # ``info["workers"] = workers``. ``getattr`` on a dict returns
-        # the default unless the dict also has an attribute by that
-        # name (it doesn't), so a user with two GPUs each configured for
-        # 2 workers got parallelism=2 instead of 4. Use the right
-        # accessor + clamp to ≥1 so a workers=0 typo can't silently
-        # hide a device.
-        if isinstance(gpu_info, dict):
-            try:
-                return max(1, int(gpu_info.get("workers", 1) or 1))
-            except (TypeError, ValueError):
-                return 1
+    # Reconcile the (possibly reused/stale) pool to the current GPU config —
+    # the same hook the webhook/single-Plex path uses so worker counts track
+    # settings. Replaces Engine B's bespoke 1.5s poller.
+    if worker_pool_callback:
         try:
-            return max(1, int(getattr(gpu_info, "workers", 1) or 1))
-        except (TypeError, ValueError):
-            return 1
+            worker_pool_callback(worker_pool)
+        except Exception as exc:
+            logger.debug("worker_pool_callback raised during {} dispatch: {}", label, exc)
 
-    from .worker_naming import (
-        cpu_worker_label as _cpu_worker_label,
-    )
-    from .worker_naming import (
-        friendly_device_label as _device_label,
-    )
-    from .worker_naming import (
-        gpu_worker_label as _gpu_worker_label,
-    )
-
-    # Pre-allocate one stable slot per concurrent worker. The slot is
-    # alive for the entire dispatch; only ``status`` and ``current_title``
-    # mutate as items pass through. Two payoffs:
-    #   1. The Workers panel shows N persistent rows (matches the legacy
-    #      WorkerPool model). No more rows flashing on/off as items
-    #      complete and the next thread picks up a microsecond later.
-    #   2. Each ThreadPool thread persistently binds to ONE slot, which
-    #      means its GPU assignment is also stable — no per-item
-    #      round-robin churn.
-    # Per-type counter so labels match the legacy WorkerPool format
-    # ("GPU Worker 1 (NVIDIA TITAN RTX)") that users already recognise
-    # — avoids two different label conventions side-by-side when a job
-    # mixes the legacy and multi-server paths.
-    # Slot identity is decoupled from thread identity so the settings
-    # poller (further down) can add/remove rows mid-job without
-    # disturbing in-flight work — the dispatcher used to bake the slot
-    # count at job start, so a user bumping NVIDIA workers 2→3 saw no
-    # change until the next job. With the decoupling: a thread acquires
-    # the semaphore, claims any free slot at runtime, releases it on
-    # finish. New slots become claimable the moment the poller appends
-    # them.
-    gpu_slots: list[dict] = []
-    _seq_state = {"slot": 0, "gpu": 0, "cpu": 0}
-
-    # The dashboard renderer (``app.js:2393-2438``) gates the
-    # progress bar / speed / ETA rendering on ``ffmpeg_started``:
-    # when ``False`` it hides those elements and shows a "Working…"
-    # placeholder (or the ``current_phase`` text when present).
-    # Without these fields on the multi-server slot dict,
-    # ``WorkerStatus`` falls back to ``False`` / ``""`` and the panel
-    # renders "Working…" for the entire run even when speed/ETA are
-    # flowing through the API — the symptom job 2395774d reproduced
-    # live.
-    #
-    # ``ffmpeg_started`` mirrors the legacy ``WorkerPool`` field
-    # (``worker.py:128`` / flipped in ``worker.py:1624``) and is
-    # flipped True by ``_slot_progress_callback`` below on the first
-    # progress tick, reset False in ``_release_slot``.
-    #
-    # ``current_phase`` is a forward-compat placeholder — no callsite
-    # writes it yet. The legacy worker populates it from log-line
-    # parsing (``worker.py:397``) for nicer pre-FFmpeg labels like
-    # "Resolving item id on EmbyTest…" / "Reusing cached frames";
-    # threading those through ``process_canonical_path`` is a separate
-    # piece of work. Empty string degrades gracefully to "Working…".
-    def _build_gpu_slot(gpu_type: str, gpu_device: str | None, gpu_info: dict | object) -> dict:
-        _seq_state["slot"] += 1
-        _seq_state["gpu"] += 1
-        return {
-            "worker_id": _seq_state["slot"],
-            "worker_type": "GPU",
-            "worker_name": _gpu_worker_label(_seq_state["gpu"], _device_label(gpu_info, gpu_device, gpu_type)),
-            "gpu_type": gpu_type,
-            "gpu_device": gpu_device,
-            "_gpu_info": gpu_info,  # kept so the poller can build matching new slots
-            "status": "idle",
-            "current_title": "",
-            "library_name": "",
-            "progress_percent": 0,
-            "speed": "0.0x",
-            "remaining_time": 0,
-            "ffmpeg_started": False,
-            "current_phase": "",
-            "_claimed_by": None,
-            "_pending_removal": False,
-        }
-
-    def _build_cpu_slot() -> dict:
-        _seq_state["slot"] += 1
-        _seq_state["cpu"] += 1
-        return {
-            "worker_id": _seq_state["slot"],
-            "worker_type": "CPU",
-            "worker_name": _cpu_worker_label(_seq_state["cpu"]),
-            "gpu_type": None,
-            "gpu_device": None,
-            "_gpu_info": None,
-            "status": "idle",
-            "current_title": "",
-            "library_name": "",
-            "progress_percent": 0,
-            "speed": "0.0x",
-            "remaining_time": 0,
-            "ffmpeg_started": False,
-            "current_phase": "",
-            "_claimed_by": None,
-            "_pending_removal": False,
-        }
-
-    for gpu_type, gpu_device, gpu_info in gpu_devices:
-        for _ in range(_read_workers_count(gpu_info)):
-            gpu_slots.append(_build_gpu_slot(gpu_type, gpu_device, gpu_info))
-    for _ in range(cpu_workers):
-        gpu_slots.append(_build_cpu_slot())
-
-    initial_concurrency = max(1, len(gpu_slots))
-    # Scan-phase concurrency (#243). ``scan_workers`` is how many items the
-    # cheap "does a fresh preview already exist?" check sweeps in parallel,
-    # decoupled from the FFmpeg-generation cap (``initial_concurrency`` — the
-    # GPU+CPU worker count). The pre-permit check in ``_process_one`` runs on
-    # these threads WITHOUT holding a generation permit, so raising this
-    # speeds the library sweep without spawning more FFmpegs.
-    #
-    # 0 = Auto → max(32, generators): exactly today's pool size, so the
-    # threads that previously sat idle-blocked on the semaphore now actually
-    # do the checking — the benefit lands at the default with no regression.
-    # An explicit value still floors at ``initial_concurrency`` so every
-    # generator can run.
-    _scan_workers_cfg = max(0, int(getattr(config, "scan_workers", 0) or 0))
-    scan_workers = _scan_workers_cfg if _scan_workers_cfg > 0 else max(32, initial_concurrency)
-    pool_max_workers = max(scan_workers, initial_concurrency)
-
-    job_manager = None
-    if job_id:
-        try:
-            from ..web.jobs import get_job_manager
-
-            job_manager = get_job_manager()
-        except Exception:
-            job_manager = None
-
-    logger.info(
-        "Multi-server {}: dispatching {} item(s) with parallelism={} (max pool={})",
-        label,
-        total,
-        initial_concurrency,
-        pool_max_workers,
-    )
-    # Fire the "dispatch has really started" hook so the job flips from
-    # PENDING to RUNNING. job_runner's _on_dispatch_start calls
-    # job_manager.start_job(); without this the multi-server full-scan
-    # path leaves the job stuck in PENDING even as items complete.
-    # Matches the equivalent call in ``_dispatch_items`` used by the
-    # webhook / legacy-plex-phase code paths.
     if on_dispatch_start:
         try:
             on_dispatch_start()
         except Exception as exc:
             logger.debug("on_dispatch_start raised: {}", exc)
-    # Surface "Dispatching N items…" up-front so the progress widget gets
-    # a real total + denominator the moment enumeration finishes — without
-    # this the bar sits at 0/0 with the stale "Querying…" label until the
-    # first item completes (can be 30s+ on the first FFmpeg pass).
+
     if progress_callback:
         try:
-            progress_callback(0, total, f"Dispatching {total} item(s) across {initial_concurrency} worker(s)…")
+            progress_callback(0, total, f"Dispatching {total} item(s)…")
         except Exception as exc:
             logger.debug("progress_callback raised on dispatch banner: {}", exc)
 
-    # Concurrency gate. Decoupled from ThreadPoolExecutor's max_workers
-    # so the hot-reload poller below can grow/shrink concurrency by
-    # adjusting the permit count alone.
-    _slots_lock = threading.Lock()
-    _concurrency_cond = threading.Condition(_slots_lock)
-    _concurrency_state = {"target": initial_concurrency, "active": 0}
+    # A real job always carries a job_id; enumeration helpers occasionally
+    # call with None (no Job row). Use a unique synthetic key so two such runs
+    # can't collide on the singleton dispatcher's tracker map.
+    effective_job_id = job_id or f"{label.replace(' ', '-')}-{uuid.uuid4().hex[:8]}"
 
-    # Flips True the first time any item claims a generation slot (i.e. the
-    # scan turned up real work). Used only to switch the job's progress label
-    # from "Checking existing previews…" to "Processed…". A plain bool write
-    # from the worker threads + a read from the single as_completed consumer;
-    # a benign stale read just shows the old label for one more tick.
-    _phase_state = {"generation_started": False}
-
-    def _acquire_concurrency() -> None:
-        # Block until the active count is below the dynamic target.
-        # If the user shrinks workers mid-job, queued threads back up
-        # here until enough active ones finish; if they grow workers
-        # the poller's notify_all wakes a queued thread immediately.
-        with _concurrency_cond:
-            while _concurrency_state["active"] >= _concurrency_state["target"]:
-                _concurrency_cond.wait()
-            _concurrency_state["active"] += 1
-
-    def _release_concurrency() -> None:
-        with _concurrency_cond:
-            _concurrency_state["active"] -= 1
-            _concurrency_cond.notify_all()
-
-    def _claim_idle_slot(thread_name: str) -> dict | None:
-        # Slots are claimed at task start (after concurrency gate),
-        # released at task end. A thread is NOT pinned to a slot —
-        # different items the same thread processes can land on
-        # different slots (whichever is free). That's necessary for
-        # hot-reload: when the user adds a new GPU slot, any waiting
-        # thread can pick it up immediately rather than only the
-        # thread that was bound to that slot at job start.
-        with _slots_lock:
-            for s in gpu_slots:
-                if s["_claimed_by"] is None and not s["_pending_removal"] and s["status"] == "idle":
-                    s["_claimed_by"] = thread_name
-                    return s
-            return None
-
-    def _release_slot(slot: dict) -> None:
-        with _slots_lock:
-            slot["status"] = "idle"
-            slot["current_title"] = ""
-            slot["_claimed_by"] = None
-            slot["progress_percent"] = 0
-            # Reset the FFmpeg-phase flags so the NEXT item this slot
-            # picks up starts in the pre-FFmpeg "Working…" state until
-            # its own progress callback flips them back. Without this
-            # reset, a slot that just finished a real FFmpeg pass keeps
-            # ``ffmpeg_started=True`` and the UI shows the previous
-            # item's stale speed/ETA on the new (pre-FFmpeg) item.
-            slot["ffmpeg_started"] = False
-            slot["current_phase"] = ""
-            # If the poller marked this slot for removal while it was
-            # busy, drop it now that it's free — the panel sees one
-            # fewer row on the next snapshot.
-            if slot["_pending_removal"]:
-                try:
-                    gpu_slots.remove(slot)
-                except ValueError:
-                    pass
-
-    def _snapshot_slots() -> list[dict]:
-        # Strip internal bookkeeping ("_claimed_by", "_pending_removal",
-        # "_gpu_info") before exposing rows to the worker_callback.
-        with _slots_lock:
-            return [{k: v for k, v in s.items() if not k.startswith("_")} for s in gpu_slots]
-
-    # ── Worker-snapshot emit throttle ─────────────────────────────────
-    # Cap snapshot emits at ~1 Hz. Pre-fix every slot claim + release
-    # called ``_emit_worker_snapshot`` immediately, so a full-library
-    # scan whose first phase is mostly "already fresh — skip FFmpeg"
-    # no-op items (each completing in ~50 ms with 4 workers → ~80 items/sec
-    # → ~160 transitions/sec) flooded the SocketIO connection. Each
-    # emit also spawned a fresh thread in ``JobManager._emit_event``,
-    # so the dashboard's browser-side event loop couldn't keep up and
-    # the Workers panel never settled long enough to render — job
-    # 8cd02fa6 reproducer.
-    #
-    # Same pattern the legacy ``WorkerPool`` already uses at
-    # ``worker.py:1245`` — "skip if <1 s since the last emit." The
-    # poller heartbeat fires every 1.5 s (> throttle) so the panel
-    # never stalls for longer than the heartbeat window even on a
-    # sustained flood. ``force=True`` bypasses the throttle for the
-    # three events the user must see immediately:
-    #   * initial dispatch banner — show the configured slots as idle
-    #   * final dispatch end — capture the all-idle terminal state
-    #   * poller-driven slot-count changes — rows added/removed
-    # Forced emits do NOT consume the throttle budget so a genuine
-    # transition immediately afterwards still produces its own emit,
-    # and the panel shows the very first claim even on sub-second
-    # dispatches.
-    throttle_s = _WORKER_EMIT_THROTTLE_S
-    _emit_state: dict = {"last_non_force_monotonic": 0.0}
-    _emit_state_lock = threading.Lock()
-
-    def _emit_worker_snapshot(force: bool = False) -> None:
-        if not worker_callback:
-            return
-        with _emit_state_lock:
-            if not force:
-                now = time.monotonic()
-                if now - _emit_state["last_non_force_monotonic"] < throttle_s:
-                    return
-                _emit_state["last_non_force_monotonic"] = now
-        try:
-            worker_callback(_snapshot_slots())
-        except Exception as exc:
-            logger.debug("worker_callback raised: {}", exc)
-
-    # ── Hot-reload settings poller ───────────────────────────────────
-    # Reads gpu_config + cpu_threads every ~1.5s and reconciles
-    # gpu_slots + concurrency target with the live setting. The user
-    # can bump NVIDIA workers from 2→3 in Settings while the job is
-    # running and see the third row appear within ~1.5s — without
-    # this the slot count was baked at job start.
-    _poller_stop = threading.Event()
-    _poller_thread: threading.Thread | None = None
-
-    def _reconcile_with_settings() -> None:
-        try:
-            from ..web.settings_manager import get_settings_manager
-
-            sm = get_settings_manager()
-            new_gpu_config = sm.gpu_config or []
-            new_cpu = max(0, int(getattr(sm, "cpu_threads", 0) or 0))
-        except Exception as exc:
-            logger.debug("hot-reload poller: settings read failed ({}); skipping tick", exc)
-            return
-
-        # Build a target {device: desired_count} map for GPUs that were
-        # in scope at job start. Devices added/removed entirely
-        # mid-job are out of scope (next job picks them up).
-        gpu_info_by_device: dict[str, tuple[str, object]] = {}
-        for gpu_type, gpu_device, gpu_info in gpu_devices:
-            if gpu_device:
-                gpu_info_by_device[gpu_device] = (gpu_type, gpu_info)
-
-        desired_gpu_per_device: dict[str, int] = {}
-        for entry in new_gpu_config:
-            if not isinstance(entry, dict):
-                continue
-            device = entry.get("device")
-            if device not in gpu_info_by_device:
-                continue
-            if not entry.get("enabled", True):
-                desired_gpu_per_device[device] = 0
-                continue
-            try:
-                desired_gpu_per_device[device] = max(0, int(entry.get("workers", 1) or 0))
-            except (TypeError, ValueError):
-                desired_gpu_per_device[device] = 1
-
-        added = 0
-        removed = 0
-        with _slots_lock:
-            # GPU diff per device
-            for device, desired in desired_gpu_per_device.items():
-                live = [
-                    s
-                    for s in gpu_slots
-                    if s["worker_type"] == "GPU" and s["gpu_device"] == device and not s["_pending_removal"]
-                ]
-                delta = desired - len(live)
-                if delta > 0:
-                    gpu_type, gpu_info = gpu_info_by_device[device]
-                    for _ in range(delta):
-                        gpu_slots.append(_build_gpu_slot(gpu_type, device, gpu_info))
-                        added += 1
-                elif delta < 0:
-                    # Prefer to retire idle slots first (immediate),
-                    # mark busy ones as pending so they retire when
-                    # they finish their current item.
-                    surplus = -delta
-                    idle_first = sorted(live, key=lambda s: 0 if s["_claimed_by"] is None else 1)
-                    for s in idle_first[:surplus]:
-                        if s["_claimed_by"] is None:
-                            try:
-                                gpu_slots.remove(s)
-                                removed += 1
-                            except ValueError:
-                                pass
-                        else:
-                            s["_pending_removal"] = True
-                            removed += 1
-            # CPU diff
-            live_cpu = [s for s in gpu_slots if s["worker_type"] == "CPU" and not s["_pending_removal"]]
-            delta = new_cpu - len(live_cpu)
-            if delta > 0:
-                for _ in range(delta):
-                    gpu_slots.append(_build_cpu_slot())
-                    added += 1
-            elif delta < 0:
-                surplus = -delta
-                idle_first = sorted(live_cpu, key=lambda s: 0 if s["_claimed_by"] is None else 1)
-                for s in idle_first[:surplus]:
-                    if s["_claimed_by"] is None:
-                        try:
-                            gpu_slots.remove(s)
-                            removed += 1
-                        except ValueError:
-                            pass
-                    else:
-                        s["_pending_removal"] = True
-                        removed += 1
-
-            new_target = sum(1 for s in gpu_slots if not s["_pending_removal"])
-            if new_target != _concurrency_state["target"]:
-                _concurrency_state["target"] = max(1, new_target)
-                _concurrency_cond.notify_all()
-
-        if added or removed:
-            logger.info(
-                "Hot-reload: gpu_config changed mid-{} — added {} slot(s), removed {} slot(s); concurrency target now {}",
-                label,
-                added,
-                removed,
-                _concurrency_state["target"],
-            )
-            # Slot-count changed — bypass the 1 Hz throttle so the
-            # panel reflects the new row count immediately.
-            _emit_worker_snapshot(force=True)
-
-    def _poller_loop() -> None:
-        while not _poller_stop.wait(1.5):
-            _reconcile_with_settings()
-            # Periodic snapshot tick so the Workers panel reflects
-            # in-flight FFmpeg progress (progress_percent / speed) within
-            # ~1.5s. Without this, the snapshot only fires at task
-            # start / end and during settings reconciliation, leaving
-            # the panel frozen at "0% @ 0.0x" through 30s+ FFmpeg
-            # passes for multi-server full scans. Throttled at 1 Hz —
-            # 1.5 s ≥ throttle so the heartbeat always passes through.
-            _emit_worker_snapshot()
-
-    def _process_one(index_and_item):
-        # D27 — register the executor's worker thread under this job's
-        # id so the per-job log handler captures every per-file
-        # Dispatch / Owners-resolved / FFmpeg / Publisher line that
-        # process_canonical_path emits. Without this, the Emby/Jellyfin
-        # full-scan path (which uses ThreadPoolExecutor directly,
-        # bypassing JobDispatcher → Worker.assign_task → register_job_thread)
-        # leaves its threads anonymous and the per-job log shows only
-        # the lifecycle markers — users see "dispatching 5000 items"
-        # then nothing for hours despite continuous activity in app.log.
-        # Idempotent re-register per call: the executor pool reuses
-        # threads across items, but every call sets the same job_id so
-        # there's no churn in _job_thread_to_job_id.
-        if job_id:
-            from .worker import register_job_thread
-
-            register_job_thread(job_id)
-
-        index, (server_cfg, item) = index_and_item
-        thread_name = threading.current_thread().name
-
-        if cancel_check and cancel_check():
-            return ("Worker", None)
-
-        # Pause gate — block (don't bail) while the queue is paused so
-        # NEW FFmpegs don't spawn after the user clicks Pause All. The
-        # dispatcher path (job_runner → JobDispatcher) already honours
-        # pause via tracker.is_paused() in _get_next_item, but the
-        # multi-server full-scan / webhook ThreadPoolExecutor path used
-        # to ignore it — pausing only halted in-flight FFmpegs (via
-        # SIGSTOP from commit 6d812ad) while the executor kept pulling
-        # the next item and launching fresh subprocesses for ~6 minutes
-        # until the queue drained. Cancel takes precedence over pause
-        # so a user who pauses then cancels isn't stuck waiting.
-        while pause_check and pause_check():
-            if cancel_check and cancel_check():
-                return ("Worker", None)
-            time.sleep(0.25)
-
-        # Pin precedence — computed up-front so the scan-phase check below
-        # and the generation call further down agree on who publishes:
-        #   1. Caller-supplied ``server_id_filter`` always wins — the user's
-        #      explicit "scan Movies on plex-default" pin from the job config.
-        #   2. No caller pin + non-Plex originator → scope to that originator.
-        #   3. No caller pin + Plex originator → fan out to every owner.
-        if server_id_filter:
-            per_item_pin = server_id_filter
-        elif server_cfg.type is not ServerType.PLEX:
-            per_item_pin = server_cfg.id
-        else:
-            per_item_pin = None
-
-        # Scan phase (#243): run the cheap pre-FFmpeg check WITHOUT holding a
-        # generation permit or a Workers-panel slot. Up to ``pool_max_workers``
-        # threads do this in parallel, so the "does a fresh preview already
-        # exist?" sweep is no longer throttled to the FFmpeg cap. Only items
-        # that genuinely need frame extraction fall through to claim a (capped)
-        # permit + slot below. ``check_only=True`` is contractually guaranteed
-        # not to run FFmpeg, so generation can NEVER happen without a permit.
-        scan_result = None
-        with failure_scope(job_id):
-            try:
-                scan_result = process_canonical_path(
-                    canonical_path=item.canonical_path,
-                    registry=registry,
-                    config=config,
-                    item_id_by_server=item.item_id_by_server or None,
-                    bundle_metadata_by_server=item.bundle_metadata_by_server or None,
-                    gpu=None,
-                    gpu_device_path=None,
-                    progress_callback=None,
-                    cancel_check=cancel_check,
-                    server_id_filter=per_item_pin,
-                    regenerate=bool(getattr(config, "regenerate_thumbnails", False)),
-                    check_only=True,
-                )
-            except CancellationError:
-                return ("Library scan", None)
-            except Exception as scan_exc:
-                # The cheap check raised unexpectedly (e.g. a transient server
-                # error mid item-id resolution). Don't decide the item here —
-                # fall through to the full generation path, which carries the
-                # complete error handling, CPU fallback, and Files-panel
-                # attribution. Worst case it spends a permit to reach the same
-                # failure, which is exactly the pre-#243 behaviour.
-                logger.debug(
-                    "Multi-server {}: scan-phase check raised for {!r} ({}: {}); routing to the full generation path.",
-                    label,
-                    item.canonical_path,
-                    type(scan_exc).__name__,
-                    scan_exc,
-                )
-                scan_result = None
-
-        if scan_result is not None and scan_result.status is not MultiServerStatus.NEEDS_GENERATION:
-            # Terminal outcome decided during the cheap scan: already-fresh
-            # skip, no-owners, source-missing, or pending-registration. None
-            # of these need FFmpeg, so record the result through the SAME
-            # folding path the generation branch uses (the return value flows
-            # into the as_completed loop) — no permit, no slot, and it never
-            # shows as a Workers-panel row. The Files-panel Worker column reads
-            # "Library scan" because that's what actually processed it.
-            return ("Library scan", scan_result)
-
-        # Item needs generation (or the check raised) — acquire a capped
-        # generation permit and a Workers-panel slot, then run the full
-        # pipeline below.
-        # Two-step acquisition: concurrency permit (gates how many
-        # threads run real work simultaneously) and slot claim (which
-        # row in the Workers panel represents this thread). The poller
-        # adjusts both atomically.
-        _acquire_concurrency()
-        slot = _claim_idle_slot(thread_name)
-        # Edge case: poller marked all live slots for removal between
-        # the acquire and the claim. Release the permit so others can
-        # proceed and bail this item.
-        if slot is None:
-            _release_concurrency()
-            return ("Worker", None)
-        # First real work found — flip the job's progress label away from
-        # "Checking existing previews…". Benign race (see _phase_state).
-        _phase_state["generation_started"] = True
-
-        # GPU assignment is *per slot*, not per item — the slot's
-        # gpu_type/gpu_device were set at slot creation so concurrency
-        # is correctly distributed across physical devices even after
-        # hot-reload reshuffles slots.
-        gpu_type = slot["gpu_type"]
-        gpu_device = slot["gpu_device"]
-        worker_label = slot["worker_name"]
-
-        # Flip the slot to "processing X" in place — never pop it.
-        # Rows persist for the whole dispatch (legacy WorkerPool
-        # model) so the Workers panel doesn't flash entries on/off.
-        with _slots_lock:
-            slot["status"] = "processing"
-            slot["current_title"] = item.title or os.path.basename(item.canonical_path)
-        # Push the snapshot the moment the thread picks up the item so
-        # the Workers panel shows activity within ~1 frame of dispatch
-        # (otherwise the panel would only update on completion — for
-        # FFmpeg passes that take 30s+ that's a very long blank stare).
-        _emit_worker_snapshot()
-
-        # ``per_item_pin`` was computed up-front (before the scan-phase
-        # check) so the check and this generation call agree on who
-        # publishes — see the pin-precedence comment above.
-
-        # Slot progress callback — updates the slot's progress_percent /
-        # speed / remaining_time fields in place during FFmpeg so the
-        # Workers panel rows show live "<progress>% @ <speed>" instead
-        # of a frozen 0.0x. Mirrors what worker._update_worker_progress
-        # does for the JobDispatcher path; without this the multi-server
-        # full-scan path (which uses ThreadPoolExecutor + the slot dict
-        # rather than the dispatcher's WorkerPool) emitted only the
-        # title, status changes, and 0% / 0.0x defaults.
-        def _slot_progress_callback(
-            progress_percent,
-            current_duration,
-            total_duration,
-            speed=None,
-            remaining_time=None,
-            frame=0,
-            fps=0,
-            q=0,
-            size=0,
-            time_str="00:00:00.00",
-            bitrate=0,
-            media_file=None,
-        ):
-            with _slots_lock:
-                slot["progress_percent"] = progress_percent
-                if speed:
-                    slot["speed"] = speed
-                if remaining_time is not None:
-                    slot["remaining_time"] = remaining_time
-                # First progress tick means FFmpeg is actually running
-                # and producing measurable output — flip the UI out of
-                # its pre-FFmpeg "Working…" branch so the user sees the
-                # real progress bar + speed + ETA. Mirrors the legacy
-                # ``WorkerPool._update_worker_progress`` (``worker.py:1624``).
-                # Reset on slot release (see ``_release_slot``) so a
-                # cache-hit / skipped-FFmpeg item that follows starts
-                # back in the "Working…" branch instead of inheriting
-                # the previous item's progress.
-                slot["ffmpeg_started"] = True
-            # Don't emit a snapshot per progress tick — that'd drown
-            # the SocketIO emit queue at 5+ updates/sec/worker. Slot
-            # state is mutated in place; the panel picks up the
-            # latest speed/remaining_time on the next snapshot. All
-            # ``_emit_worker_snapshot`` calls (claim, release, poller
-            # heartbeat) share the 1 Hz throttle defined inside this
-            # function — see the long comment near ``_emit_worker_snapshot``.
-
-        # Bind the worker thread's failure-tracking scope to this
-        # job so any FFmpeg failure inside ``process_canonical_path``
-        # → ``generate_images`` → ``record_failure`` is attributed
-        # to the right job's run summary. Without this scope every
-        # FFmpeg failure on the multi-server full-scan path was
-        # logged as "Internal bookkeeping bug: failure ... reported
-        # outside an active job" — the codebase's self-flagged
-        # diagnostic. The Worker dispatch path (worker.py:_process_item)
-        # has the equivalent ``with failure_scope(self.current_job_id)``;
-        # this scan path was missing it.
-        with failure_scope(job_id):
-            try:
-                result = process_canonical_path(
-                    canonical_path=item.canonical_path,
-                    registry=registry,
-                    config=config,
-                    item_id_by_server=item.item_id_by_server or None,
-                    bundle_metadata_by_server=item.bundle_metadata_by_server or None,
-                    gpu=gpu_type,
-                    gpu_device_path=gpu_device,
-                    progress_callback=_slot_progress_callback,
-                    cancel_check=cancel_check,
-                    server_id_filter=per_item_pin,
-                    regenerate=bool(getattr(config, "regenerate_thumbnails", False)),
-                )
-                return (worker_label, result)
-            except CodecNotSupportedError as exc:
-                # In-place GPU→CPU fallback. Pre-fix the bare except below
-                # swallowed CodecNotSupportedError, so the user-visible
-                # "retrying on CPU automatically" log line from
-                # generator.py / multi_server.py was a lie on full-scan
-                # jobs — no CPU retry ever ran. Worker-pool path has the
-                # equivalent fallback at jobs/worker.py:557-613; this
-                # mirrors it for the orchestrator's executor path.
-                # Live regression: 4 Re:ZERO episodes in job a90c9b87
-                # (TV Shows full scan, 2026-05-14) hit this and were
-                # marked failed despite the announced fallback.
-                if cancel_check and cancel_check():
-                    logger.info(
-                        "Multi-server {}: cancelled before CPU fallback for {!r}",
-                        label,
-                        item.canonical_path,
-                    )
-                    return (worker_label, None)
-                logger.warning(
-                    "Multi-server {}: GPU couldn't process {!r} ({}); retrying on CPU. "
-                    "If this happens for many files, your GPU may not support the codec.",
-                    label,
-                    item.canonical_path,
-                    exc,
-                )
-                try:
-                    result = process_canonical_path(
-                        canonical_path=item.canonical_path,
-                        registry=registry,
-                        config=config,
-                        item_id_by_server=item.item_id_by_server or None,
-                        bundle_metadata_by_server=item.bundle_metadata_by_server or None,
-                        gpu=None,
-                        gpu_device_path=None,
-                        progress_callback=_slot_progress_callback,
-                        cancel_check=cancel_check,
-                        server_id_filter=per_item_pin,
-                        regenerate=bool(getattr(config, "regenerate_thumbnails", False)),
-                    )
-                    logger.info(
-                        "Multi-server {}: completed CPU fallback for {!r}",
-                        label,
-                        item.canonical_path,
-                    )
-                    return (worker_label, result)
-                except CancellationError:
-                    # Distinct branch (mirrors jobs/worker.py:598-602) so the
-                    # user-visible log shows "cancelled during fallback" rather
-                    # than getting collapsed into the generic "CPU fallback also
-                    # failed (CancellationError: …)" message.
-                    logger.info(
-                        "Multi-server {}: cancelled during CPU fallback for {!r}",
-                        label,
-                        item.canonical_path,
-                    )
-                    return (worker_label, None)
-                except Exception as fallback_exc:
-                    logger.warning(
-                        "Multi-server {}: CPU fallback also failed for {!r} ({}: {}). "
-                        "Marking this file as failed; other items keep processing.",
-                        label,
-                        item.canonical_path,
-                        type(fallback_exc).__name__,
-                        fallback_exc,
-                    )
-                    return (worker_label, None)
-            except Exception as exc:
-                logger.warning(
-                    "Multi-server {}: per-item processing failed for {!r} ({}: {}). "
-                    "Other items in this run will still be processed.",
-                    label,
-                    item.canonical_path,
-                    type(exc).__name__,
-                    exc,
-                )
-                return (worker_label, None)
-            finally:
-                # Release the slot (auto-removes if poller flagged it)
-                # and the concurrency permit. Order matters: free the
-                # slot first so the snapshot reflects "idle" before
-                # another thread grabs it.
-                _release_slot(slot)
-                _emit_worker_snapshot()
-                _release_concurrency()
-
-    completed = 0
-    # Per-server publisher tally for this dispatch. Folded after every
-    # completed item and mirrored onto the Job via the fixed-size
-    # ``set_publishers`` call (one entry per server). Safe to mutate
-    # without a lock because ``as_completed`` yields finished futures
-    # back to **a single consumer thread** (the for-loop below) — the
-    # workers themselves never touch this dict. If this loop ever
-    # multiplexes consumption across threads, wrap the fold +
-    # set_publishers call in a ``threading.Lock``.
-    # Replaces the original
-    # per-item ``append_publishers`` (one row per file × server) which
-    # made publishers_json grow O(items × servers) — a 117k-item full
-    # library scan re-encoded and SQLite-UPSERTed an 11.8 MB blob after
-    # every item, throttling sustained throughput to <10 items/sec on a
-    # workload that's almost entirely "all fresh" stat() checks. The
-    # legacy dispatcher path was already moved to this shape in commit
-    # 1ecf099; this catches the full-scan path up.
-    publishers_aggregate: dict[str, dict] = {}
-    # Index inputs alongside their outcomes so the per-item record can
-    # surface the canonical path even when ``result is None`` (the
-    # exception-swallowed branch). Without this the Files panel showed
-    # only the surviving rows; the failures were just a number on the
-    # summary chip with no per-file attribution.
-    indexed_items = list(enumerate(items))
-    # Force the initial worker snapshot so the dashboard's Workers
-    # panel shows the configured slots as "idle" the moment the
-    # dispatch starts, instead of staying blank until the first
-    # item-claim transition (which the 1 Hz throttle can defer for
-    # up to a second after the panel first asks). Bypasses the
-    # throttle because there's nothing to coalesce yet.
-    _emit_worker_snapshot(force=True)
-    _poller_thread = threading.Thread(
-        target=_poller_loop,
-        name=f"multi-server-poller-{label}",
-        daemon=True,
+    tracker = dispatcher.submit_items(
+        job_id=effective_job_id,
+        items=plain_items,
+        config=config,
+        registry=registry,
+        title_max_width=200,
+        library_name="",
+        callbacks={
+            "progress_callback": progress_callback,
+            "worker_callback": worker_callback,
+            "cancel_check": cancel_check,
+            "pause_check": pause_check,
+        },
+        priority=PRIORITY_NORMAL,
     )
-    _poller_thread.start()
-    try:
-        pool_ctx = ThreadPoolExecutor(max_workers=pool_max_workers)
-    except Exception:
-        _poller_stop.set()
-        raise
-    # Why submit() + as_completed() instead of ``pool.map``:
-    # ``ThreadPoolExecutor.map`` returns results in **submission order**,
-    # so a slow item near the front of the queue stalls progress for
-    # every faster item behind it — workers are completing in parallel
-    # but the consumer is blocked at the head, so the
-    # ``progress_callback`` (and its SocketIO emit) never fires until
-    # the slow item completes. Job 9eb79d9c surfaced this on a Jellyfin
-    # full-library scan: numerator stuck at ~5/5000 for minutes, then
-    # jumped to ~700/5000 the instant the user cancelled. The
-    # ``as_completed`` iterator yields each future the moment its
-    # worker is done, so progress reflects real completion order.
-    with pool_ctx as pool:
-        future_to_input: dict = {
-            pool.submit(_process_one, indexed_item): indexed_item for indexed_item in indexed_items
-        }
-        for future in as_completed(future_to_input):
-            idx, (_server_cfg, item) = future_to_input[future]
-            try:
-                worker_label, result = future.result()
-            except Exception as exc:
-                # ``_process_one`` already wraps its own work in try/except
-                # and returns ``(worker_label, None)`` on failure, so
-                # this branch is only reached if _process_one itself
-                # raised before its try-block (or the pool surfaced an
-                # InterruptedError). Treat it the same as the
-                # exception-swallowed path: log, count as failure, no
-                # per-file row (canonical_path is still known).
-                logger.warning(
-                    "Multi-server {}: future.result() raised for {!r} ({}: {}). Treating as a failed item.",
-                    label,
-                    item.canonical_path,
-                    type(exc).__name__,
-                    exc,
-                )
-                worker_label, result = "Worker", None
-            completed += 1
-            if progress_callback:
-                try:
-                    # Until the scan turns up the first item that needs FFmpeg,
-                    # the job is sweeping the library for existing previews —
-                    # surface that rather than "Processed", which reads as
-                    # generation. Flips to "Processed" the moment any item
-                    # claims a generation slot (#243).
-                    phase_msg = (
-                        f"Checking existing previews… {completed}/{total}"
-                        if not _phase_state["generation_started"]
-                        else f"Processed {completed}/{total}"
-                    )
-                    progress_callback(completed, total, phase_msg)
-                except Exception:
-                    pass
-            # ``worker_label`` already came back from _process_one as the
-            # actual stable slot name (e.g. "NVIDIA TITAN RTX #1") that
-            # processed this item — so the Files panel's Worker column
-            # shows the same identity as the Workers panel's row.
-            if result is None:
-                # _process_one swallowed an exception (FFmpeg crash, codec
-                # not supported, etc.). Count it as a failed item so the
-                # outcome counter — and the Job UI badge — surface it
-                # instead of silently reporting "Completed".
-                counts["failed"] = counts.get("failed", 0) + 1
-                # Persist a Files-panel row so the user can see *which*
-                # file failed without grepping the log. Without this, a
-                # batch with 50 failures showed "0 file(s)" in the panel
-                # and the failures only existed as a counter on the chip.
-                try:
-                    _notify_file_result(
-                        item.canonical_path,
-                        ProcessingResult.FAILED,
-                        "process_canonical_path raised — see app log for traceback",
-                        worker_label,
-                        servers=[],
-                    )
-                except Exception as exc:
-                    logger.debug("Could not notify failed file result for {}: {}", item.canonical_path, exc)
-                continue
-            for pub in result.publishers or []:
-                key = (pub.status.value if hasattr(pub.status, "value") else str(pub.status)).lower()
-                counts[key] = counts.get(key, 0) + 1
-            # Empty-publisher aggregate statuses (SKIPPED_FILE_NOT_FOUND,
-            # NO_OWNERS, NO_FRAMES, MultiServerStatus.FAILED when frame
-            # generation raised before any publisher ran) still represent
-            # a processed item. Without this fold, the item is counted in
-            # ``completed`` but disappears from the outcome totals — which
-            # is how the deea99db job reported "128007 processed" but
-            # only "128002 in outcome". Mirrors _outcome_for_multi_server_status
-            # so the counter key and the Files-panel outcome string agree.
-            if not (result.publishers or []):
-                aggregate_status = getattr(result, "status", None)
-                if aggregate_status is MultiServerStatus.SKIPPED_FILE_NOT_FOUND:
-                    counts["skipped_file_not_found"] = counts.get("skipped_file_not_found", 0) + 1
-                elif aggregate_status is MultiServerStatus.NO_OWNERS:
-                    counts["no_owners"] = counts.get("no_owners", 0) + 1
-                elif aggregate_status is MultiServerStatus.NO_FRAMES:
-                    # NO_FRAMES already invoked ``record_failure`` inside
-                    # ``generate_images`` — rolling it into ``failed`` here
-                    # keeps the end-of-run "X failed file(s)" list and the
-                    # "N of T item(s) failed" summary aligned. Without this
-                    # they diverge (deea99db: 1-in-list vs 2-in-summary).
-                    counts["failed"] = counts.get("failed", 0) + 1
-                elif aggregate_status is MultiServerStatus.FAILED:
-                    counts["failed"] = counts.get("failed", 0) + 1
-            rows = _publisher_rows_from_result(result, result.canonical_path)
-            if job_manager is not None:
-                # Fold this item's per-server outcomes into the running
-                # aggregate, then mirror the bounded summary onto the
-                # Job. Per-file × per-server detail still lands in the
-                # Files-panel JSONL via ``_notify_file_result`` below —
-                # that's the right home for it (append-only, capped
-                # caller-side; see web/jobs.record_file_result).
-                fold_publisher_rows_into_aggregate(publishers_aggregate, rows)
-                try:
-                    job_manager.set_publishers(job_id, list(publishers_aggregate.values()))
-                except Exception as exc:
-                    logger.debug("Could not set publisher aggregate for job {}: {}", job_id, exc)
-            # Live Files-panel row. The multi-server dispatch path
-            # bypasses Worker → _persist (it calls process_canonical_path
-            # directly via the ThreadPoolExecutor), so without this hook
-            # the JSONL file stays empty for the entire run and users
-            # see "0 file(s)" mid-job despite continuous activity.
-            try:
-                outcome = _outcome_for_multi_server_status(result.status)
-                _notify_file_result(
-                    result.canonical_path,
-                    outcome,
-                    (result.message or "").strip(),
-                    worker_label,
-                    servers=rows,
-                )
-            except Exception as exc:
-                logger.debug("Could not notify file result for {}: {}", result.canonical_path, exc)
-
-    # Stop the hot-reload poller and clear any persistent slot rows
-    # from the panel snapshot. Daemon thread, but explicit shutdown
-    # avoids a 1.5s tail of poller activity after the dispatch
-    # returns.
-    _poller_stop.set()
-    try:
-        _poller_thread.join(timeout=2.0)
-    except Exception:
-        pass
-    # Force one final emit so the panel sees the terminal all-idle
-    # state. Without it, a last-item-release transition within the
-    # throttle window leaves the panel showing a stale "processing"
-    # row until the next job clears it.
-    _emit_worker_snapshot(force=True)
-    logger.info("Multi-server {} complete: {} item(s) processed.", label, completed)
-    return counts
+    tracker.wait()
+    logger.info("Multi-server {} complete: {} item(s) processed.", label, tracker.completed)
+    return tracker.get_result()["outcome"]
 
 
 def _enumerate_items_for_servers(
@@ -1663,6 +803,7 @@ def _run_full_scan_multi_server(
     job_id: str | None = None,
     worker_callback=None,
     on_dispatch_start=None,
+    worker_pool_callback=None,
     warnings_out: list[str] | None = None,
 ) -> dict:
     """Multi-server full-library scan via the per-vendor :class:`VendorProcessor`.
@@ -1780,6 +921,7 @@ def _run_full_scan_multi_server(
         server_id_filter=server_id_filter,
         worker_callback=worker_callback,
         on_dispatch_start=on_dispatch_start,
+        worker_pool_callback=worker_pool_callback,
     )
 
 
@@ -1796,6 +938,7 @@ def _run_recently_added_multi_server(
     job_id: str | None = None,
     worker_callback=None,
     on_dispatch_start=None,
+    worker_pool_callback=None,
     warnings_out: list[str] | None = None,
 ) -> dict:
     """Recently-added scan for any vendor via :class:`VendorProcessor`.
@@ -1880,6 +1023,7 @@ def _run_recently_added_multi_server(
         server_id_filter=server_id_filter,
         worker_callback=worker_callback,
         on_dispatch_start=on_dispatch_start,
+        worker_pool_callback=worker_pool_callback,
     )
 
 
@@ -2512,6 +1656,7 @@ def run_processing(
                 job_id=job_id,
                 worker_callback=worker_callback,
                 on_dispatch_start=on_dispatch_start,
+                worker_pool_callback=worker_pool_callback,
                 warnings_out=scan_warnings,
             )
             result: dict = {"outcome": outcome_counts}

--- a/media_preview_generator/jobs/orchestrator.py
+++ b/media_preview_generator/jobs/orchestrator.py
@@ -709,11 +709,21 @@ def _dispatch_processable_items(
         gpu_slots.append(_build_cpu_slot())
 
     initial_concurrency = max(1, len(gpu_slots))
-    # Generous ThreadPool ceiling so the hot-reload poller can grow the
-    # active worker count without bumping into max_workers. Tasks waiting
-    # on the concurrency semaphore are cheap (one idle thread each) so
-    # 32 is fine; users wanting more can restart.
-    pool_max_workers = max(initial_concurrency, 32)
+    # Scan-phase concurrency (#243). ``scan_workers`` is how many items the
+    # cheap "does a fresh preview already exist?" check sweeps in parallel,
+    # decoupled from the FFmpeg-generation cap (``initial_concurrency`` — the
+    # GPU+CPU worker count). The pre-permit check in ``_process_one`` runs on
+    # these threads WITHOUT holding a generation permit, so raising this
+    # speeds the library sweep without spawning more FFmpegs.
+    #
+    # 0 = Auto → max(32, generators): exactly today's pool size, so the
+    # threads that previously sat idle-blocked on the semaphore now actually
+    # do the checking — the benefit lands at the default with no regression.
+    # An explicit value still floors at ``initial_concurrency`` so every
+    # generator can run.
+    _scan_workers_cfg = max(0, int(getattr(config, "scan_workers", 0) or 0))
+    scan_workers = _scan_workers_cfg if _scan_workers_cfg > 0 else max(32, initial_concurrency)
+    pool_max_workers = max(scan_workers, initial_concurrency)
 
     job_manager = None
     if job_id:
@@ -758,6 +768,13 @@ def _dispatch_processable_items(
     _slots_lock = threading.Lock()
     _concurrency_cond = threading.Condition(_slots_lock)
     _concurrency_state = {"target": initial_concurrency, "active": 0}
+
+    # Flips True the first time any item claims a generation slot (i.e. the
+    # scan turned up real work). Used only to switch the job's progress label
+    # from "Checking existing previews…" to "Processed…". A plain bool write
+    # from the worker threads + a read from the single as_completed consumer;
+    # a benign stale read just shows the old label for one more tick.
+    _phase_state = {"generation_started": False}
 
     def _acquire_concurrency() -> None:
         # Block until the active count is below the dynamic target.
@@ -1024,6 +1041,74 @@ def _dispatch_processable_items(
                 return ("Worker", None)
             time.sleep(0.25)
 
+        # Pin precedence — computed up-front so the scan-phase check below
+        # and the generation call further down agree on who publishes:
+        #   1. Caller-supplied ``server_id_filter`` always wins — the user's
+        #      explicit "scan Movies on plex-default" pin from the job config.
+        #   2. No caller pin + non-Plex originator → scope to that originator.
+        #   3. No caller pin + Plex originator → fan out to every owner.
+        if server_id_filter:
+            per_item_pin = server_id_filter
+        elif server_cfg.type is not ServerType.PLEX:
+            per_item_pin = server_cfg.id
+        else:
+            per_item_pin = None
+
+        # Scan phase (#243): run the cheap pre-FFmpeg check WITHOUT holding a
+        # generation permit or a Workers-panel slot. Up to ``pool_max_workers``
+        # threads do this in parallel, so the "does a fresh preview already
+        # exist?" sweep is no longer throttled to the FFmpeg cap. Only items
+        # that genuinely need frame extraction fall through to claim a (capped)
+        # permit + slot below. ``check_only=True`` is contractually guaranteed
+        # not to run FFmpeg, so generation can NEVER happen without a permit.
+        scan_result = None
+        with failure_scope(job_id):
+            try:
+                scan_result = process_canonical_path(
+                    canonical_path=item.canonical_path,
+                    registry=registry,
+                    config=config,
+                    item_id_by_server=item.item_id_by_server or None,
+                    bundle_metadata_by_server=item.bundle_metadata_by_server or None,
+                    gpu=None,
+                    gpu_device_path=None,
+                    progress_callback=None,
+                    cancel_check=cancel_check,
+                    server_id_filter=per_item_pin,
+                    regenerate=bool(getattr(config, "regenerate_thumbnails", False)),
+                    check_only=True,
+                )
+            except CancellationError:
+                return ("Library scan", None)
+            except Exception as scan_exc:
+                # The cheap check raised unexpectedly (e.g. a transient server
+                # error mid item-id resolution). Don't decide the item here —
+                # fall through to the full generation path, which carries the
+                # complete error handling, CPU fallback, and Files-panel
+                # attribution. Worst case it spends a permit to reach the same
+                # failure, which is exactly the pre-#243 behaviour.
+                logger.debug(
+                    "Multi-server {}: scan-phase check raised for {!r} ({}: {}); routing to the full generation path.",
+                    label,
+                    item.canonical_path,
+                    type(scan_exc).__name__,
+                    scan_exc,
+                )
+                scan_result = None
+
+        if scan_result is not None and scan_result.status is not MultiServerStatus.NEEDS_GENERATION:
+            # Terminal outcome decided during the cheap scan: already-fresh
+            # skip, no-owners, source-missing, or pending-registration. None
+            # of these need FFmpeg, so record the result through the SAME
+            # folding path the generation branch uses (the return value flows
+            # into the as_completed loop) — no permit, no slot, and it never
+            # shows as a Workers-panel row. The Files-panel Worker column reads
+            # "Library scan" because that's what actually processed it.
+            return ("Library scan", scan_result)
+
+        # Item needs generation (or the check raised) — acquire a capped
+        # generation permit and a Workers-panel slot, then run the full
+        # pipeline below.
         # Two-step acquisition: concurrency permit (gates how many
         # threads run real work simultaneously) and slot claim (which
         # row in the Workers panel represents this thread). The poller
@@ -1036,6 +1121,9 @@ def _dispatch_processable_items(
         if slot is None:
             _release_concurrency()
             return ("Worker", None)
+        # First real work found — flip the job's progress label away from
+        # "Checking existing previews…". Benign race (see _phase_state).
+        _phase_state["generation_started"] = True
 
         # GPU assignment is *per slot*, not per item — the slot's
         # gpu_type/gpu_device were set at slot creation so concurrency
@@ -1057,24 +1145,9 @@ def _dispatch_processable_items(
         # FFmpeg passes that take 30s+ that's a very long blank stare).
         _emit_worker_snapshot()
 
-        # Pin precedence:
-        #   1. Caller-supplied ``server_id_filter`` always wins — that's
-        #      the user's explicit "scan Movies on plex-default" pin from
-        #      the job config. Without this we'd fan out to Jellyfin/Emby
-        #      on a Plex-pinned job (job d9918149 reproducer: every Plex
-        #      file got a JellyTest publisher attempt that failed because
-        #      no Jellyfin item_id existed).
-        #   2. No caller pin + non-Plex originator → scope to that
-        #      originator. Plex isn't reachable on this install.
-        #   3. No caller pin + Plex originator → fan out to every
-        #      owning server (the original cross-vendor publish path
-        #      that benefits multi-vendor installs).
-        if server_id_filter:
-            per_item_pin = server_id_filter
-        elif server_cfg.type is not ServerType.PLEX:
-            per_item_pin = server_cfg.id
-        else:
-            per_item_pin = None
+        # ``per_item_pin`` was computed up-front (before the scan-phase
+        # check) so the check and this generation call agree on who
+        # publishes — see the pin-precedence comment above.
 
         # Slot progress callback — updates the slot's progress_percent /
         # speed / remaining_time fields in place during FFmpeg so the
@@ -1313,7 +1386,17 @@ def _dispatch_processable_items(
             completed += 1
             if progress_callback:
                 try:
-                    progress_callback(completed, total, f"Processed {completed}/{total}")
+                    # Until the scan turns up the first item that needs FFmpeg,
+                    # the job is sweeping the library for existing previews —
+                    # surface that rather than "Processed", which reads as
+                    # generation. Flips to "Processed" the moment any item
+                    # claims a generation slot (#243).
+                    phase_msg = (
+                        f"Checking existing previews… {completed}/{total}"
+                        if not _phase_state["generation_started"]
+                        else f"Processed {completed}/{total}"
+                    )
+                    progress_callback(completed, total, phase_msg)
                 except Exception:
                     pass
             # ``worker_label`` already came back from _process_one as the

--- a/media_preview_generator/jobs/orchestrator.py
+++ b/media_preview_generator/jobs/orchestrator.py
@@ -494,14 +494,14 @@ def _enumerate_plex_full_scan_items(
     library_ids = list(getattr(config, "plex_library_ids", None) or []) or None
     # Mirror the Emby/Jellyfin multi-server enumerator's "Querying…"
     # banner (see ``_enumerate_items_for_servers``). A full Plex library
-    # enumeration on a large TV library can take 30–120s before the
+    # enumeration on a large TV library can take a while before the
     # first item is yielded via ``list_canonical_paths``; without this
     # the progress bar sits at "0/0" with no message and the job looks
     # frozen — live user report on job 90301a18. Log at INFO so it
     # lands in the per-job log file too (the UI's Job Detail tab reads
     # from that file, not the progress_callback stream).
     _label = plex_cfg.name or plex_cfg.id or plex_cfg.type.value
-    logger.info("Querying {} library… (can take 30–120s for large libraries)", _label)
+    logger.info("Querying {} library… (can take a while for large libraries)", _label)
     if progress_callback is not None:
         try:
             progress_callback(0, 0, f"Querying {_label} library…")

--- a/media_preview_generator/jobs/worker.py
+++ b/media_preview_generator/jobs/worker.py
@@ -68,6 +68,32 @@ def is_job_thread_for(thread_id: int, job_id: str) -> bool:
         return _job_thread_to_job_id.get(thread_id) == job_id
 
 
+def resolve_per_item_pin(config, item, registry) -> str | None:
+    """Decide which single server (if any) a dispatch should publish to.
+
+    Shared by the processing path (:meth:`Worker._process_item`) and the
+    dispatcher's checking stage so both agree on who publishes — a divergence
+    would let the cheap check skip an item whose pinned server is actually
+    stale. Precedence:
+
+    1. Caller-supplied ``config.server_id_filter`` always wins (explicit
+       "publish to this server only" pin from the job config).
+    2. No caller pin + non-Plex originator → scope to that originator's id
+       (``item.server_id`` carries the vendor that fired the webhook).
+    3. No caller pin + Plex originator → fan out (return None).
+    """
+    from ..servers.base import ServerType as _ST
+
+    _config_pin = getattr(config, "server_id_filter", None) or None
+    if _config_pin:
+        return _config_pin
+    if getattr(item, "server_id", None):
+        origin_cfg = registry.get_config(item.server_id) if registry else None
+        origin_is_plex = bool(origin_cfg and origin_cfg.type is _ST.PLEX)
+        return item.server_id if not origin_is_plex else None
+    return None
+
+
 class Worker:
     """Represents a worker thread for processing media items."""
 
@@ -414,17 +440,7 @@ class Worker:
             #   3. No caller pin + Plex originator → fan out (the
             #      cross-vendor publish path Plex+Emby+Jellyfin installs
             #      depend on).
-            from ..servers.base import ServerType as _ST
-
-            _config_pin = getattr(config, "server_id_filter", None) or None
-            if _config_pin:
-                per_item_pin: str | None = _config_pin
-            elif item.server_id:
-                origin_cfg = registry.get_config(item.server_id) if registry else None
-                origin_is_plex = bool(origin_cfg and origin_cfg.type is _ST.PLEX)
-                per_item_pin = item.server_id if not origin_is_plex else None
-            else:
-                per_item_pin = None
+            per_item_pin: str | None = resolve_per_item_pin(config, item, registry)
 
             # ``webhook_source`` lives on Config when this dispatch came
             # from a webhook (Sonarr/Radarr/Plex/…). Use it as the gate

--- a/media_preview_generator/jobs/worker.py
+++ b/media_preview_generator/jobs/worker.py
@@ -422,24 +422,12 @@ class Worker:
                 # Single-writer (worker thread) → no lock needed.
                 self.current_phase = text or ""
 
-            # Pin precedence — matches ``_dispatch_processable_items`` so the
-            # worker dispatch path and the multi-server scan path agree on
-            # who publishes:
-            #   1. Caller-supplied ``config.server_id_filter`` always wins
-            #      — that's the explicit "publish to this server only" pin
-            #      from the job config (set by job_runner when the job's
-            #      config carries ``server_id``). Pinned vendor webhooks
-            #      depend on this. Without it the worker fans out to every
-            #      owning server, which on Steve's setup means a
-            #      Plex-pinned webhook silently writes Emby BIFs +
-            #      Jellyfin trickplay too (audit P1 / D34-shape regression).
-            #   2. No caller pin + non-Plex originator → scope to that
-            #      originator's id. The item's ``server_id`` carries the
-            #      vendor that fired the webhook; falling out to "fan out
-            #      to all" leaks publishes to other vendors.
-            #   3. No caller pin + Plex originator → fan out (the
-            #      cross-vendor publish path Plex+Emby+Jellyfin installs
-            #      depend on).
+            # Pin precedence (config pin wins → non-Plex originator scopes to
+            # itself → Plex originator fans out) lives in resolve_per_item_pin,
+            # the single source both this generation path and the dispatcher's
+            # checking stage share so they agree on who publishes. A Plex-pinned
+            # webhook fanning out would silently write Emby/Jellyfin previews too
+            # (audit P1 / D34-shape regression) — see resolve_per_item_pin.
             per_item_pin: str | None = resolve_per_item_pin(config, item, registry)
 
             # ``webhook_source`` lives on Config when this dispatch came

--- a/media_preview_generator/jobs/worker_naming.py
+++ b/media_preview_generator/jobs/worker_naming.py
@@ -1,13 +1,12 @@
 """Shared worker-row labelling so every code path agrees on the same shape.
 
-Three independent code paths build the rows the dashboard's Workers panel
+Two independent code paths build the rows the dashboard's Workers panel
 renders:
 
-1. :func:`media_preview_generator.jobs.orchestrator._dispatch_processable_items` —
-   the multi-server dispatch loop (Plex full scan, Emby/Jellyfin scans).
-2. :class:`media_preview_generator.jobs.worker.WorkerPool` — the legacy Plex
-   single-server path (only fires on a pure-Plex install today).
-3. :func:`media_preview_generator.web.routes.api_jobs._build_idle_workers_from_config`
+1. :class:`media_preview_generator.jobs.worker.WorkerPool` — the live worker
+   snapshots for every active job (webhooks, single-Plex scans, and the
+   multi-server scans that now feed the shared :class:`~media_preview_generator.jobs.dispatcher.JobDispatcher`).
+2. :func:`media_preview_generator.web.routes.api_jobs._build_idle_workers_from_config`
    — synthesised idle entries returned by ``GET /api/jobs/workers`` when no
    job is currently active.
 

--- a/media_preview_generator/processing/_shared.py
+++ b/media_preview_generator/processing/_shared.py
@@ -114,7 +114,7 @@ class _MediaServerProcessor:
                 return
             # Announce the per-library query at INFO so both the app
             # log and the per-job log panel show user-meaningful
-            # progress. Large TV libraries (10k+ items) take 30-120s
+            # progress. Large TV libraries (10k+ items) can take a while
             # to enumerate; without this the UI appears frozen.
             logger.info(
                 "Querying library {}/{}: {!r} (this can take a while for large libraries)",

--- a/media_preview_generator/processing/generator.py
+++ b/media_preview_generator/processing/generator.py
@@ -198,8 +198,8 @@ def clear_failures() -> None:
 # Dispatch reads the active ``job_id`` from ``_failure_job_id_var`` — the
 # same ContextVar ``failure_scope`` uses. Every call site of
 # ``_notify_file_result`` already runs inside ``failure_scope(job_id)``
-# (worker.py:_process_item and orchestrator.py:_process_one), so no
-# caller changes were needed.
+# (worker.py:_process_item for generation and dispatcher.py:_run_check for
+# the checking stage), so no caller changes were needed.
 #
 # The ``""`` bucket keeps the old scope-less API working for unit tests
 # that exercise ``_notify_file_result`` directly without wrapping in a

--- a/media_preview_generator/processing/multi_server.py
+++ b/media_preview_generator/processing/multi_server.py
@@ -46,6 +46,7 @@ from ..output.journal import clear_meta, outputs_fresh_for_source, write_meta
 from ..servers.base import LibraryNotYetIndexedError, MediaServer, ServerConfig, ServerType
 from .frame_cache import get_frame_cache
 from .generator import (
+    CancellationError,
     CodecNotSupportedError,
     _cleanup_temp_directory,
     generate_images,
@@ -1718,6 +1719,13 @@ def process_canonical_path(
                     "No action needed; this is a normal fallback for codecs your GPU doesn't support.",
                     canonical_path,
                 )
+                raise
+            except CancellationError:
+                # Cancellation (job cancelled / container restart mid-FFmpeg) is
+                # NOT a frame-extraction failure — don't log the scary "corrupt
+                # video file" traceback or mark it FAILED here. Re-raise so the
+                # worker's CancellationError handler records it cleanly.
+                logger.info("Frame extraction cancelled for {} — stopping this file.", canonical_path)
                 raise
             except Exception as exc:
                 logger.exception(

--- a/media_preview_generator/processing/multi_server.py
+++ b/media_preview_generator/processing/multi_server.py
@@ -77,6 +77,12 @@ class MultiServerStatus(str, Enum):
     NO_OWNERS = "no_owners"  # no enabled library covers the path
     FAILED = "failed"  # generation or every publisher failed
     NO_FRAMES = "no_frames"  # FFmpeg produced 0 frames (unrecoverable)
+    # Returned ONLY by check_only=True calls: every pre-FFmpeg step ran and
+    # the item genuinely needs frame extraction. Lets the orchestrator's
+    # high-concurrency scan phase decide whether to spend a generation permit
+    # without ever crossing the FFmpeg boundary itself. A real (check_only=
+    # False) call never returns this — it would just generate.
+    NEEDS_GENERATION = "needs_generation"
 
 
 @dataclass
@@ -1199,6 +1205,7 @@ def process_canonical_path(
     display_name: str | None = None,
     source: str | None = None,
     originating_job_id: str | None = None,
+    check_only: bool = False,
 ) -> MultiServerResult:
     """Process ``canonical_path`` and publish to every owning server.
 
@@ -1216,6 +1223,20 @@ def process_canonical_path(
             knows the id (typical for Plex / Emby / Jellyfin webhooks).
         regenerate: When True, publish even if all output paths already
             exist on disk.
+        check_only: When True, run every pre-FFmpeg step (publisher
+            resolution, source-missing / sibling-mount-rebind probe, the
+            all-fresh short-circuit and its ``trigger_refresh`` +
+            ``cleanup_orphaned_outputs`` side effects, the regenerate
+            meta-clear) exactly as a normal call, then return
+            :attr:`MultiServerStatus.NEEDS_GENERATION` at the FFmpeg
+            boundary instead of extracting frames. Terminal outcomes
+            (``SKIPPED``, ``PUBLISHED`` pending-registration, ``NO_OWNERS``,
+            ``SKIPPED_FILE_NOT_FOUND``) return exactly as they do without
+            this flag — they never reach the FFmpeg boundary. The full-scan
+            orchestrator uses this so its high-concurrency scan phase can
+            decide whether to spend a (capped) generation permit before any
+            FFmpeg can run. Default callers leave this False and never
+            observe ``NEEDS_GENERATION``.
 
     Returns:
         :class:`MultiServerResult` aggregating per-publisher outcomes.
@@ -1546,6 +1567,22 @@ def process_canonical_path(
                 clear_meta(adapter.compute_output_paths(_probe_bundle(server.id), server, item_id))
             except Exception:
                 continue
+
+    # check_only boundary: everything above here is the cheap pre-FFmpeg
+    # work (resolution, source-missing/sibling-rebind probe, all-fresh
+    # short-circuit + its cleanup/refresh side effects, regenerate
+    # meta-clear). All terminal outcomes (SKIPPED, PUBLISHED pending,
+    # NO_OWNERS, SKIPPED_FILE_NOT_FOUND) have already returned. Reaching
+    # here means the item genuinely needs frame extraction — so a
+    # check_only caller stops now and reports NEEDS_GENERATION rather than
+    # crossing into the heavy FFmpeg path below. This is the ONLY place
+    # NEEDS_GENERATION is produced.
+    if check_only:
+        return MultiServerResult(
+            canonical_path=canonical_path,
+            status=MultiServerStatus.NEEDS_GENERATION,
+            message="Outputs missing or stale; FFmpeg required",
+        )
 
     # Frame cache: when enabled, the second+ webhook for the same file
     # within the cache TTL skips FFmpeg entirely. Disabled callers

--- a/media_preview_generator/processing/multi_server.py
+++ b/media_preview_generator/processing/multi_server.py
@@ -1432,7 +1432,13 @@ def process_canonical_path(
             pass
 
     if not regenerate:
-        _phase("Checking existing previews…")
+        # "Checking existing previews…" belongs to the decoupled checking
+        # stage (check_only=True, run on its own threads). When a generation
+        # worker runs this same freshness probe before FFmpeg (check_only=
+        # False), surfacing "Checking…" on the worker card reads as the old
+        # "GPU worker stuck checking" bug — the worker is preparing to
+        # generate, not sweeping the library. Label it accordingly.
+        _phase("Checking existing previews…" if check_only else "Preparing to generate…")
         all_fresh = True
         for server, adapter, item_id_hint in publishers:
             try:

--- a/media_preview_generator/servers/plex.py
+++ b/media_preview_generator/servers/plex.py
@@ -1504,11 +1504,11 @@ class PlexServer(MediaServer):
             # call. Bracket it with two INFO lines so the per-job log
             # has something between the existing "Querying library …"
             # banner and the first item dispatch, instead of a silent
-            # 30-120s gap on a large library.
+            # gap on a large library.
             if target.METADATA_TYPE == "episode":
                 logger.info(
                     "Plex library {!r}: requesting full episode list from server "
-                    "(plexapi paginates internally; this can take 30-120s for large libraries)…",
+                    "(plexapi paginates internally; this can take a while for large libraries)…",
                     target.title,
                 )
                 results = retry_plex_call(target.search, libtype="episode")
@@ -1531,7 +1531,7 @@ class PlexServer(MediaServer):
             elif target.METADATA_TYPE == "movie":
                 logger.info(
                     "Plex library {!r}: requesting full movie list from server "
-                    "(plexapi paginates internally; this can take 30-120s for large libraries)…",
+                    "(plexapi paginates internally; this can take a while for large libraries)…",
                     target.title,
                 )
                 results = retry_plex_call(target.search)

--- a/media_preview_generator/web/routes/api_settings.py
+++ b/media_preview_generator/web/routes/api_settings.py
@@ -304,6 +304,10 @@ def get_settings():
             "gpu_config": settings.gpu_config,
             "gpu_threads": settings.gpu_threads,
             "cpu_threads": settings.cpu_threads,
+            # Library-scanning concurrency for full scans. 0 = Auto. Clamped
+            # to [0, 256] so a manually-edited settings.json can't surface an
+            # absurd value in the UI. See issue #243.
+            "scan_workers": max(0, min(256, int(settings.get("scan_workers", 0) or 0))),
             "ffmpeg_threads": settings.get("ffmpeg_threads", 2),
             "thumbnail_interval": settings.thumbnail_interval,
             "thumbnail_quality": settings.thumbnail_quality,
@@ -354,6 +358,7 @@ _SAVE_SETTINGS_ALLOWED_FIELDS = (
     "gpu_config",
     "gpu_threads",
     "cpu_threads",
+    "scan_workers",
     "ffmpeg_threads",
     "thumbnail_interval",
     "thumbnail_quality",
@@ -377,6 +382,7 @@ _SAVE_SETTINGS_ALLOWED_FIELDS = (
 
 _SAVE_SETTINGS_INT_FIELDS = (
     "cpu_threads",
+    "scan_workers",
     "gpu_threads",
     "ffmpeg_threads",
     "thumbnail_interval",
@@ -445,6 +451,17 @@ def _validate_and_coerce_settings_updates(data: dict) -> tuple[dict | None, tupl
         if value < 1 or value > 10:
             return None, (
                 jsonify({"error": "max_concurrent_jobs must be between 1 and 10"}),
+                400,
+            )
+
+    # Library-scanning concurrency. 0 = Auto; an explicit value is bounded
+    # to [1, 256]. Reject out-of-range rather than silently clamping (same
+    # contract as max_concurrent_jobs) so Save shows the user what they get.
+    if "scan_workers" in updates:
+        value = updates["scan_workers"]
+        if value < 0 or value > 256:
+            return None, (
+                jsonify({"error": "scan_workers must be between 0 (Auto) and 256"}),
                 400,
             )
 

--- a/media_preview_generator/web/routes/job_runner.py
+++ b/media_preview_generator/web/routes/job_runner.py
@@ -62,7 +62,14 @@ def _classify_job_completion(
     nothing_resolved = total_paths > 0 and resolved_count == 0 and not spawned_retry_id
     retry_exhausted = is_retry and bool(retry_paths) and not spawned_retry_id
 
-    if all_items_failed or all_not_found or nothing_resolved or retry_exhausted:
+    # A retry chain that exhausted is only a *total* failure (red) when nothing
+    # succeeded. If it still produced previews (success_total > 0), it's a
+    # partial failure (amber) — the same rule every other gate already follows
+    # (all_items_failed requires success_total == 0). Without the guard, a retry
+    # job that generated N previews but couldn't register a few genuinely-
+    # missing files showed red "Failed" (job 67f7bf2a: generated 11, 0 hard
+    # failures, 26 unregistered missing files → was red, should be amber).
+    if all_items_failed or all_not_found or nothing_resolved or (retry_exhausted and success_total == 0):
         return "error"
     return "warning"
 

--- a/media_preview_generator/web/routes/job_runner.py
+++ b/media_preview_generator/web/routes/job_runner.py
@@ -701,7 +701,7 @@ def _start_job_async(job_id: str, config_overrides: dict | None = None):
                     _slot_held = True
                     # Flip to RUNNING the moment the slot is acquired —
                     # library enumeration / webhook resolution IS
-                    # active work (often 30-120s of real API calls) and
+                    # active work (real API calls that can take a while) and
                     # the user should see that reflected in the status.
                     # PENDING is now reserved for jobs truly idle
                     # (queued at the gate, waiting retry backoff, or

--- a/media_preview_generator/web/templates/settings.html
+++ b/media_preview_generator/web/templates/settings.html
@@ -193,6 +193,20 @@
                     </small>
                 </div>
 
+                <!-- Library Scanning -->
+                <h6 class="mb-3"><i class="bi bi-search me-2"></i>Library Scanning</h6>
+                <div class="row mb-2">
+                    <div class="col-md-6 mb-3">
+                        <label for="scanWorkers" class="form-label">
+                            Files checked at once
+                            <button type="button" class="info-icon ms-1" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top" title="During a full library scan, how many files are checked in parallel for an existing preview. Checking is light disk work and does NOT add FFmpeg/GPU load — only the GPU and CPU worker counts above control how many previews generate at once. Higher values speed up the &quot;skip already-done files&quot; sweep on large libraries; lower it if a single spinning HDD struggles. 0 = Auto."><i class="bi bi-info-circle"></i></button>
+                        </label>
+                        <input type="number" class="form-control has-stepper" id="scanWorkers"
+                               min="0" max="256" value="0" placeholder="Auto">
+                        <div class="form-text">How many files to check for an existing preview in parallel. <strong>0 = Auto</strong> (recommended). Does not change how many previews generate at once.</div>
+                    </div>
+                </div>
+
                 <!-- Thumbnail Settings -->
                 <h6 class="mb-3"><i class="bi bi-image me-2"></i>Thumbnail Settings</h6>
                 <div class="row">
@@ -785,6 +799,7 @@ async function loadSettings() {
         // Store gpu_config for the GPU panel
         window._gpuConfig = settings.gpu_config || [];
         document.getElementById('cpuThreads').value = settings.cpu_threads ?? 1;
+        document.getElementById('scanWorkers').value = settings.scan_workers ?? 0;
         document.getElementById('thumbnailInterval').value = settings.thumbnail_interval || 10;
         // Issue #238 — keep the slow-path notice in sync with the loaded value.
         // Defined inside DOMContentLoaded; reference it via window so the call
@@ -951,6 +966,7 @@ async function saveAllSettings() {
     const settings = {
         gpu_config: collectGpuConfig(),
         cpu_threads: parseInt(document.getElementById('cpuThreads').value),
+        scan_workers: parseInt(document.getElementById('scanWorkers').value) || 0,
         thumbnail_interval: parseInt(document.getElementById('thumbnailInterval').value),
         thumbnail_quality: parseInt(document.getElementById('thumbnailQuality').value),
         tonemap_algorithm: document.getElementById('tonemapAlgorithm').value,

--- a/media_preview_generator/web/templates/settings.html
+++ b/media_preview_generator/web/templates/settings.html
@@ -203,7 +203,7 @@
                         </label>
                         <input type="number" class="form-control has-stepper" id="scanWorkers"
                                min="0" max="256" value="0" placeholder="Auto">
-                        <div class="form-text">How many files to check for an existing preview in parallel. <strong>0 = Auto</strong> (recommended). Does not change how many previews generate at once.</div>
+                        <div class="form-text">How many files to check for an existing preview in parallel. <strong>0 = Auto</strong> (recommended). Does not change how many previews generate at once.<span id="scanWorkersAutoHint" class="text-info"></span></div>
                     </div>
                 </div>
 
@@ -686,12 +686,50 @@ document.addEventListener('DOMContentLoaded', function() {
     // the GPU status fetch in parallel but render after both resolve.
     const gpuPromise = fetchGpuStatus();
     Promise.all([
-        loadSettings().then(() => renderGpuFromFetch(gpuPromise)),
+        loadSettings().then(() => renderGpuFromFetch(gpuPromise)).then(updateScanWorkersAutoHint),
         loadVersionInfo(),
     ]).finally(() => {
         // Refresh scrollspy after dynamic content changes page height
         bootstrap.ScrollSpy.getInstance(document.body)?.refresh();
     });
+
+    // Keep the "Auto resolves to N" hint live as the inputs that feed the
+    // formula change. GPU worker edits happen inside #gpuConfigList (rendered
+    // by gpu_config_panel.js), so delegate from the container.
+    ['scanWorkers', 'cpuThreads'].forEach((id) => {
+        document.getElementById(id)?.addEventListener('input', updateScanWorkersAutoHint);
+    });
+    const gpuList = document.getElementById('gpuConfigList');
+    gpuList?.addEventListener('input', updateScanWorkersAutoHint);
+    gpuList?.addEventListener('change', updateScanWorkersAutoHint);
+
+    // Mirrors JobDispatcher._resolve_scan_workers: Auto (0) → max(32,
+    // processing workers), where processing workers = enabled GPU workers +
+    // CPU threads. Shows what Auto lands on right now; clears when an explicit
+    // value is set.
+    function updateScanWorkersAutoHint() {
+        const hintEl = document.getElementById('scanWorkersAutoHint');
+        if (!hintEl) return;
+        const raw = parseInt(document.getElementById('scanWorkers').value, 10);
+        if (raw && raw > 0) {
+            hintEl.textContent = '';
+            return;
+        }
+        let gpuWorkers = 0;
+        try {
+            (collectGpuConfig() || []).forEach((g) => {
+                if (g && g.enabled) gpuWorkers += parseInt(g.workers, 10) || 0;
+            });
+        } catch (e) {
+            /* GPU panel not rendered yet — fall back to CPU only */
+        }
+        const cpu = parseInt(document.getElementById('cpuThreads').value, 10) || 0;
+        const generators = Math.max(1, gpuWorkers + cpu);
+        const resolved = Math.max(32, generators);
+        hintEl.textContent =
+            ` Auto right now: ${resolved} (the larger of 32 and your ${generators} preview ` +
+            `worker${generators === 1 ? '' : 's'}).`;
+    }
 
     // Auto-save: all stateful inputs/selects inside .settings-content
     // kick the shared debounced save helper.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,6 +430,30 @@ def _neutralize_setup_logging(request, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _reset_shared_dispatcher():
+    """Tear down the singleton JobDispatcher around every test.
+
+    Webhooks, single-Plex scans AND (since #243) multi-vendor scans all feed
+    one shared ``JobDispatcher`` singleton with a long-lived background loop
+    thread and a tracker map. A test that submits to it and doesn't reset
+    leaves that loop running inside the xdist worker — its trackers, threads
+    and registered callbacks then bleed into unrelated tests on the same
+    worker (observed: ``test_processing_multi_server`` flaking only under the
+    full parallel run, green in isolation). Resetting before and after each
+    test keeps the singleton from crossing test boundaries. No-op when no
+    dispatcher was created.
+    """
+    try:
+        from media_preview_generator.jobs.dispatcher import reset_dispatcher
+    except ImportError:
+        yield
+        return
+    reset_dispatcher()
+    yield
+    reset_dispatcher()
+
+
+@pytest.fixture(autouse=True)
 def _neutralize_real_world_calls(request, monkeypatch):
     """Stub out the network / hardware calls that ``run_job`` would
     otherwise make on a developer's laptop or on an unsandboxed CI runner.

--- a/tests/journeys/test_journey_start_job_async_branches.py
+++ b/tests/journeys/test_journey_start_job_async_branches.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import json
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -300,16 +301,16 @@ class TestStartJobAsyncHappyPath:
         )
 
         def fake_process(canonical_path, config, registry, **kwargs):
-            from media_preview_generator.processing.multi_server import (
-                DispatchResult,
-                PublisherStatus,
-            )
+            # Terminal SKIPPED so the checking stage records it inline and the
+            # dispatch completes (the hook we assert on fires at dispatch start
+            # regardless; the run must return for the assertion to be reached).
+            from media_preview_generator.processing.multi_server import MultiServerStatus
 
-            return DispatchResult(
+            return SimpleNamespace(
                 canonical_path=canonical_path,
-                status=PublisherStatus.PUBLISHED,
-                publisher_results=[],
-                frame_count=1,
+                status=MultiServerStatus.SKIPPED,
+                publishers=[],
+                message="",
             )
 
         hook_calls: list[None] = []
@@ -317,9 +318,17 @@ class TestStartJobAsyncHappyPath:
         def hook():
             hook_calls.append(None)
 
-        fake_config = MagicMock()
-        fake_config.cpu_threads = 0
-        fake_config.working_tmp_folder = str(tmp_path)
+        # A realistic config (not a bare MagicMock): the unified dispatcher
+        # reads gpu_threads/cpu_threads/scan_workers/regenerate_thumbnails and
+        # a MagicMock's auto-attributes break int()/branching.
+        fake_config = SimpleNamespace(
+            gpu_threads=0,
+            cpu_threads=1,
+            scan_workers=0,
+            regenerate_thumbnails=False,
+            server_id_filter=None,
+            working_tmp_folder=str(tmp_path),
+        )
 
         with (
             app.app_context(),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1113,6 +1113,78 @@ class TestLoadConfig:
     @patch("subprocess.run")
     @patch("os.path.exists")
     @patch("os.path.isdir")
+    @patch("os.listdir")
+    @patch("os.access")
+    @patch("os.statvfs", create=True)
+    @patch("media_preview_generator.logging_config.setup_logging")
+    def test_load_config_scan_workers_default_auto_and_clamp(
+        self,
+        mock_logging,
+        mock_statvfs,
+        mock_access,
+        mock_listdir,
+        mock_isdir,
+        mock_exists,
+        mock_run,
+        mock_which,
+    ):
+        """scan_workers: missing→0 (Auto), explicit kept, out-of-range clamped."""
+        from media_preview_generator.config import clear_config_cache
+        from media_preview_generator.web.settings_manager import get_settings_manager
+
+        mock_which.return_value = "/usr/bin/ffmpeg"
+        mock_run.return_value = MagicMock(returncode=0, stdout="ffmpeg version 7.0.0")
+
+        def mock_listdir_fn(path):
+            if "tmp" in path or path.startswith("/tmp"):
+                return []
+            if path.endswith("/localhost") or ("/localhost" in path and not path.endswith("Media")):
+                return list("0123456789abcdef")
+            if path.endswith("/Media"):
+                return ["localhost"]
+            return ["Cache", "Media", "Metadata", "Plug-ins", "Logs"]
+
+        mock_exists.side_effect = lambda path: True
+        mock_isdir.return_value = True
+        mock_listdir.side_effect = mock_listdir_fn
+        mock_access.return_value = True
+        statvfs_result = MagicMock()
+        statvfs_result.f_frsize = 4096
+        statvfs_result.f_bavail = 1024 * 1024 * 250
+        mock_statvfs.return_value = statvfs_result
+
+        base = {
+            "plex_url": "http://localhost:32400",
+            "plex_token": "test_token",
+            "plex_config_folder": "/config/plex/Library/Application Support/Plex Media Server",
+            "cpu_threads": 1,
+        }
+        sm = get_settings_manager()
+
+        # Missing key → Auto sentinel 0 (orchestrator resolves it).
+        sm.apply_changes(dict(base))
+        clear_config_cache()
+        assert load_config().scan_workers == 0
+
+        # Explicit value preserved.
+        sm.apply_changes({**base, "scan_workers": 64})
+        clear_config_cache()
+        assert load_config().scan_workers == 64
+
+        # Above the ceiling clamps to 256.
+        sm.apply_changes({**base, "scan_workers": 9999})
+        clear_config_cache()
+        assert load_config().scan_workers == 256
+
+        # Negative garbage falls back to Auto.
+        sm.apply_changes({**base, "scan_workers": -5})
+        clear_config_cache()
+        assert load_config().scan_workers == 0
+
+    @patch("shutil.which")
+    @patch("subprocess.run")
+    @patch("os.path.exists")
+    @patch("os.path.isdir")
     @patch("os.access")
     @patch("os.statvfs", create=True)
     @patch("media_preview_generator.logging_config.setup_logging")

--- a/tests/test_dispatcher_checking_stage.py
+++ b/tests/test_dispatcher_checking_stage.py
@@ -1,0 +1,262 @@
+"""Stage-1 tests for the dispatcher's checking stage (issue #243 unification).
+
+The shared :class:`JobDispatcher` now runs a ``check_only`` scan pass on
+submitted items BEFORE they can claim a GPU/CPU processing worker:
+
+* items already fresh (or otherwise terminal) are recorded straight away —
+  no processing worker is ever used,
+* only items that report NEEDS_GENERATION reach the processing workers,
+* the processing-worker count still caps concurrent FFmpeg work even though
+  the checking pool sweeps at higher concurrency,
+* accounting matches the item count regardless of which stage finished each
+  item.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+from media_preview_generator.jobs.dispatcher import JobDispatcher
+from media_preview_generator.jobs.worker import WorkerPool
+from media_preview_generator.processing.multi_server import (
+    MultiServerResult,
+    MultiServerStatus,
+)
+from tests.conftest import _ms, _pi_list_or_passthrough  # noqa: F401
+
+PCP = "media_preview_generator.processing.multi_server.process_canonical_path"
+
+
+def _make_config(cpu_threads=1, scan_workers=0):
+    config = MagicMock()
+    config.cpu_threads = cpu_threads
+    config.gpu_threads = 0
+    config.scan_workers = scan_workers
+    config.worker_pool_timeout = 5
+    config.regenerate_thumbnails = False
+    config.server_id_filter = None
+    return config
+
+
+def _needs_gen(canonical_path):
+    return MultiServerResult(canonical_path=canonical_path, status=MultiServerStatus.NEEDS_GENERATION)
+
+
+def test_fresh_item_recorded_without_processing_worker():
+    pool = WorkerPool(cpu_workers=1, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+    gen_calls: list[str] = []
+
+    def pcp(**kwargs):
+        if kwargs.get("check_only"):
+            return _ms("skipped", canonical_path=kwargs["canonical_path"])
+        gen_calls.append(kwargs["canonical_path"])
+        return _ms("generated", canonical_path=kwargs["canonical_path"])
+
+    with patch(PCP, side_effect=pcp):
+        tracker = dispatcher.submit_items(
+            job_id="j-fresh",
+            items=_pi_list_or_passthrough([("k1", "Fresh", "movie")]),
+            config=_make_config(),
+            registry=MagicMock(),
+        )
+        assert tracker.wait(timeout=10)
+
+    assert gen_calls == [], "a fresh item must never reach a processing/generation call"
+    assert tracker.successful == 1
+    assert tracker.outcome_counts.get("skipped_bif_exists", 0) == 1
+    dispatcher.shutdown()
+
+
+def test_needs_generation_item_reaches_processing_worker():
+    pool = WorkerPool(cpu_workers=1, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+    gen_calls: list[str] = []
+
+    def pcp(**kwargs):
+        if kwargs.get("check_only"):
+            return _needs_gen(kwargs["canonical_path"])
+        gen_calls.append(kwargs["canonical_path"])
+        return _ms("generated", canonical_path=kwargs["canonical_path"])
+
+    with patch(PCP, side_effect=pcp):
+        tracker = dispatcher.submit_items(
+            job_id="j-gen",
+            items=_pi_list_or_passthrough([("k1", "New", "movie")]),
+            config=_make_config(),
+            registry=MagicMock(),
+        )
+        assert tracker.wait(timeout=10)
+
+    assert len(gen_calls) == 1, "a NEEDS_GENERATION item must be processed by a worker"
+    assert tracker.successful == 1
+    assert tracker.outcome_counts.get("generated", 0) == 1
+    dispatcher.shutdown()
+
+
+def test_mixed_skip_and_generate_accounting_matches_item_count():
+    pool = WorkerPool(cpu_workers=2, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+
+    def pcp(**kwargs):
+        path = kwargs["canonical_path"]
+        if kwargs.get("check_only"):
+            return _ms("skipped", canonical_path=path) if "skip" in path else _needs_gen(path)
+        return _ms("generated", canonical_path=path)
+
+    items = _pi_list_or_passthrough(
+        [(f"skip{i}", f"Skip {i}", "movie") for i in range(3)] + [(f"gen{i}", f"Gen {i}", "movie") for i in range(2)]
+    )
+    with patch(PCP, side_effect=pcp):
+        tracker = dispatcher.submit_items(
+            job_id="j-mixed",
+            items=items,
+            config=_make_config(cpu_threads=2),
+            registry=MagicMock(),
+        )
+        assert tracker.wait(timeout=10)
+
+    assert tracker.completed == 5, "every item must be recorded exactly once"
+    assert tracker.outcome_counts.get("skipped_bif_exists", 0) == 3
+    assert tracker.outcome_counts.get("generated", 0) == 2
+    dispatcher.shutdown()
+
+
+def test_processing_cap_holds_under_high_check_concurrency():
+    """Core #243 property on the dispatcher: even though the checking pool is
+    wide, simultaneous generation never exceeds the processing-worker count.
+    """
+    cap = 2
+    pool = WorkerPool(cpu_workers=cap, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+
+    active = 0
+    max_active = 0
+    lock = threading.Lock()
+
+    def pcp(**kwargs):
+        nonlocal active, max_active
+        if kwargs.get("check_only"):
+            return _needs_gen(kwargs["canonical_path"])
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        try:
+            time.sleep(0.02)
+        finally:
+            with lock:
+                active -= 1
+        return _ms("generated", canonical_path=kwargs["canonical_path"])
+
+    items = _pi_list_or_passthrough([(f"k{i}", f"F{i}", "movie") for i in range(20)])
+    with patch(PCP, side_effect=pcp):
+        tracker = dispatcher.submit_items(
+            job_id="j-cap",
+            items=items,
+            config=_make_config(cpu_threads=cap, scan_workers=16),
+            registry=MagicMock(),
+        )
+        assert tracker.wait(timeout=20)
+
+    assert max_active <= cap, f"generation concurrency {max_active} exceeded processing cap {cap}"
+    assert tracker.completed == 20
+    dispatcher.shutdown()
+
+
+def test_checked_item_file_result_routes_to_its_job():
+    """HIGH-regression: the check thread must run inside failure_scope so a
+    checked item's Files-panel row routes to THIS job's callback. Without it
+    (register_job_thread alone routes only logs), _notify_file_result lands in
+    the anonymous "" bucket and the per-file row is dropped — the data-loss
+    the Architecture Review flagged.
+    """
+    from media_preview_generator.processing.generator import set_file_result_callback
+
+    pool = WorkerPool(cpu_workers=1, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+    received: list = []
+    set_file_result_callback(lambda *a, **k: received.append((a, k)), job_id="j-route")
+    try:
+        with patch(PCP, side_effect=lambda **kw: _ms("skipped", canonical_path=kw["canonical_path"])):
+            tracker = dispatcher.submit_items(
+                job_id="j-route",
+                items=_pi_list_or_passthrough([("k1", "F", "movie")]),
+                config=_make_config(),
+                registry=MagicMock(),
+            )
+            assert tracker.wait(timeout=10)
+        assert received, "checked item's file result must route to the job's callback (needs failure_scope)"
+    finally:
+        set_file_result_callback(None, job_id="j-route")
+        dispatcher.shutdown()
+
+
+def test_check_forwards_resolved_pin_to_process_canonical_path():
+    """D34 shape: the check call must forward the resolved per-item pin as
+    server_id_filter, exactly like the processing worker — a wrong pin here
+    means a wrong skip decision (missing preview). resolve_per_item_pin's
+    own matrix is covered in test_worker; here we lock in that the check
+    path forwards whatever it returns.
+    """
+    pool = WorkerPool(cpu_workers=1, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+    captured: dict = {}
+
+    def pcp(**kwargs):
+        if kwargs.get("check_only"):
+            captured["server_id_filter"] = kwargs.get("server_id_filter")
+            return _ms("skipped", canonical_path=kwargs["canonical_path"])
+        return _ms("generated", canonical_path=kwargs["canonical_path"])
+
+    with (
+        patch("media_preview_generator.jobs.worker.resolve_per_item_pin", return_value="pinned-srv"),
+        patch(PCP, side_effect=pcp),
+    ):
+        tracker = dispatcher.submit_items(
+            job_id="j-pin",
+            items=_pi_list_or_passthrough([("k1", "F", "movie")]),
+            config=_make_config(),
+            registry=MagicMock(),
+        )
+        assert tracker.wait(timeout=10)
+
+    assert captured.get("server_id_filter") == "pinned-srv", (
+        f"check call must forward the resolved pin; got {captured.get('server_id_filter')!r}"
+    )
+    dispatcher.shutdown()
+
+
+def test_cancel_during_checking_completes_cleanly():
+    pool = WorkerPool(cpu_workers=1, gpu_workers=0, selected_gpus=[])
+    dispatcher = JobDispatcher(pool)
+    cancelled = {"v": False}
+
+    def pcp(**kwargs):
+        if kwargs.get("check_only"):
+            time.sleep(0.01)
+            return _ms("skipped", canonical_path=kwargs["canonical_path"])
+        return _ms("generated", canonical_path=kwargs["canonical_path"])
+
+    items = _pi_list_or_passthrough([(f"k{i}", f"F{i}", "movie") for i in range(50)])
+    with patch(PCP, side_effect=pcp):
+        tracker = dispatcher.submit_items(
+            job_id="j-cancel",
+            items=items,
+            config=_make_config(),
+            registry=MagicMock(),
+            callbacks={"cancel_check": lambda: cancelled["v"]},
+        )
+        cancelled["v"] = True
+        # Must terminate (not hang) and mark done.
+        assert tracker.wait(timeout=10)
+        assert tracker.done_event.is_set()
+    # Accounting invariant on cancel: no item is recorded more than once
+    # (over-count would mean a check + a cancel-drain both counted it). An
+    # item in-flight in a check thread at cancel time may legitimately be
+    # uncounted (cancel can't see it), so the bound is <=, not ==.
+    assert tracker.successful + tracker.failed <= tracker.total_items, (
+        f"over-counted on cancel: {tracker.successful}+{tracker.failed} > {tracker.total_items}"
+    )
+    dispatcher.shutdown()

--- a/tests/test_dispatcher_kwargs_matrix.py
+++ b/tests/test_dispatcher_kwargs_matrix.py
@@ -42,6 +42,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from media_preview_generator.jobs.orchestrator import _run_full_scan_multi_server
+from media_preview_generator.processing.multi_server import MultiServerStatus
 from media_preview_generator.processing.types import ProcessableItem
 from media_preview_generator.servers.base import ServerConfig, ServerType
 
@@ -121,7 +122,19 @@ def _drive_dispatcher(
     ):
         mock_sm.return_value.get.return_value = [settings_entry]
         mock_registry.from_settings.return_value = registry_mock
-        mock_process.return_value = MagicMock(publishers=[])
+
+        # Post-#243 the dispatcher runs a cheap ``check_only`` scan pass on
+        # every item before it spends a generation permit. Return
+        # NEEDS_GENERATION there so the item flows on to a real generation
+        # call — that's the call this matrix pins the full kwarg shape of
+        # (it carries gpu/gpu_device_path/progress_callback). The scan-phase
+        # check_only call deliberately passes gpu=None/progress_callback=None.
+        def _pcp(**kwargs):
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            return MagicMock(publishers=[])
+
+        mock_process.side_effect = _pcp
 
         _run_full_scan_multi_server(
             expected_config,
@@ -129,8 +142,9 @@ def _drive_dispatcher(
             server_id_filter=caller_pin,
         )
 
-    mock_process.assert_called_once()
-    return mock_process.call_args.kwargs, cfg, registry_mock, expected_config
+    gen_calls = [c for c in mock_process.call_args_list if not c.kwargs.get("check_only")]
+    assert len(gen_calls) == 1, f"expected exactly one generation call, got {len(gen_calls)}"
+    return gen_calls[0].kwargs, cfg, registry_mock, expected_config
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatcher_kwargs_matrix.py
+++ b/tests/test_dispatcher_kwargs_matrix.py
@@ -101,6 +101,11 @@ def _drive_dispatcher(
 
     registry_mock = MagicMock()
     registry_mock.configs.return_value = [cfg]
+    # resolve_per_item_pin reads the originator's type via
+    # registry.get_config(item.server_id) to decide Plex-fans-out (None) vs
+    # non-Plex-scopes-to-self. Model it so the matrix exercises the real
+    # branch instead of a bare MagicMock (whose .type is never ServerType.PLEX).
+    registry_mock.get_config.return_value = cfg
 
     item = ProcessableItem(
         canonical_path="/data/movies/x.mkv",
@@ -113,6 +118,13 @@ def _drive_dispatcher(
 
     settings_entry = {"id": server_id, "type": server_type.value, "enabled": True}
     expected_config = _config(**(cfg_kwargs or {}))
+    # Production derives the scan's sid_filter FROM config.server_id_filter
+    # (run_processing: ``sid_filter = getattr(config, "server_id_filter")``),
+    # so the caller pin always lives on config — which is exactly what
+    # resolve_per_item_pin reads. Model that here; otherwise the pin reaches
+    # enumeration (the arg) but not the per-item resolver, and a Plex
+    # originator wrongly fans out instead of honouring the pin.
+    expected_config.server_id_filter = caller_pin
 
     with (
         patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,

--- a/tests/test_full_scan_multi_server.py
+++ b/tests/test_full_scan_multi_server.py
@@ -14,14 +14,26 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from requests.exceptions import ReadTimeout as requests_ReadTimeout
 
+from media_preview_generator.jobs.dispatcher import reset_dispatcher
 from media_preview_generator.jobs.orchestrator import _run_full_scan_multi_server
 from media_preview_generator.processing import ProcessingResult
 from media_preview_generator.processing.types import ProcessableItem
 from media_preview_generator.servers.base import ServerConfig, ServerType
 
 MODULE = "media_preview_generator.jobs.orchestrator"
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_dispatcher():
+    # _dispatch_processable_items now feeds the singleton JobDispatcher. Reset
+    # it around every test so a prior test's (shut-down) worker pool can't be
+    # reused via get_dispatcher() — that left tracker.wait() blocking forever.
+    reset_dispatcher()
+    yield
+    reset_dispatcher()
 
 
 def _config(cpu_threads: int = 1):
@@ -178,42 +190,6 @@ class TestMultiServerFullScan:
         # process_canonical_path fired for both items.
         assert mock_process.call_count == 2
 
-    def test_aggregates_per_publisher_outcomes_into_processing_result_counts(self, tmp_path):
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        registry_mock = MagicMock()
-        registry_mock.configs.return_value = [cfg]
-
-        proc = MagicMock()
-        proc.list_canonical_paths.return_value = iter(
-            [
-                ProcessableItem(canonical_path="/x.mkv", server_id="srv-a"),
-                ProcessableItem(canonical_path="/y.mkv", server_id="srv-a"),
-            ]
-        )
-
-        # Two items, each producing different publish outcomes.
-        result_x = MagicMock(publishers=[MagicMock(status=MagicMock(value="published"))])
-        result_y = MagicMock(publishers=[MagicMock(status=MagicMock(value="failed"))])
-
-        with (
-            patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
-            patch("media_preview_generator.servers.ServerRegistry") as mock_registry,
-            patch("media_preview_generator.processing.get_processor_for", return_value=proc),
-            patch(
-                "media_preview_generator.processing.multi_server.process_canonical_path",
-                side_effect=[result_x, result_y],
-            ),
-        ):
-            mock_sm.return_value.get.return_value = [
-                {"id": "srv-a", "type": "jellyfin", "enabled": True},
-            ]
-            mock_registry.from_settings.return_value = registry_mock
-
-            counts = _run_full_scan_multi_server(_config(), selected_gpus=[])
-
-        assert counts.get("published", 0) == 1
-        assert counts.get("failed", 0) == 1
-
     def test_empty_publisher_aggregate_statuses_are_counted(self, tmp_path):
         """Counter reconciliation regression (job deea99db).
 
@@ -296,9 +272,10 @@ class TestMultiServerFullScan:
         # item; they must roll into `failed` so the end-of-run summary
         # matches the failures list.
         assert counts.get("failed", 0) == 2, counts
-        # NO_OWNERS is neither failure nor success; it gets its own bucket
-        # so the summary can distinguish "couldn't publish" from "didn't try".
-        assert counts.get("no_owners", 0) == 1, counts
+        # Per-item counting maps NO_OWNERS → no_media_parts (mirrors
+        # Worker._record_outcome; ProcessingResult has no dedicated no_owners
+        # bucket). Still counted in exactly one bucket — just the per-file key.
+        assert counts.get("no_media_parts", 0) == 1, counts
 
     def test_zero_items_logs_warning_not_info(self, tmp_path):
         """When the scan walks the server but enumerates zero items, the user
@@ -434,6 +411,11 @@ class TestPinnedFilterForwardedToProcessCanonicalPath:
 
         registry_mock = MagicMock()
         registry_mock.configs.return_value = [cfg_plex]
+        # The unified path resolves the originator's type via
+        # registry.get_config(item.server_id) (resolve_per_item_pin); a Plex
+        # originator must fan out (None). Engine B read this off the per-tuple
+        # ServerConfig instead, so this mapping wasn't needed before.
+        registry_mock.get_config.return_value = cfg_plex
 
         proc = MagicMock()
         proc.list_canonical_paths.return_value = iter(
@@ -861,9 +843,16 @@ class TestEnumerationStatusBanner:
 
         progress_calls: list[tuple[int, int, str]] = []
 
+        from media_preview_generator.processing.multi_server import MultiServerStatus
+
         with patch(
             "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(publishers=[], canonical_path="/x"),
+            return_value=SimpleNamespace(
+                status=MultiServerStatus.SKIPPED,
+                message="",
+                publishers=[],
+                canonical_path="/x",
+            ),
         ):
             _dispatch_processable_items(
                 items=items,
@@ -910,7 +899,12 @@ class TestFileResultEmissionFromMultiServerDispatch:
         def _cb(file_path, outcome_str, reason, worker, servers=None):
             recorded.append((file_path, outcome_str, reason, worker, servers or []))
 
-        set_file_result_callback(_cb)
+        # Register under the job_id the dispatch runs in (the production
+        # pattern — job_runner does set_file_result_callback(cb, job_id=job_id)
+        # with the same id it passes to the scan). The unified dispatch runs
+        # each item under failure_scope(job_id), which never falls back to the
+        # "" bucket, so scope and registration must share the id.
+        set_file_result_callback(_cb, job_id="job-fr")
         try:
             with patch(
                 "media_preview_generator.processing.multi_server.process_canonical_path",
@@ -934,10 +928,11 @@ class TestFileResultEmissionFromMultiServerDispatch:
                     config=_config(),
                     registry=MagicMock(),
                     selected_gpus=[],
+                    job_id="job-fr",
                     label="full scan",
                 )
         finally:
-            set_file_result_callback(None)
+            set_file_result_callback(None, job_id="job-fr")
 
         assert len(recorded) == 2, f"Expected 2 file rows, got {len(recorded)}: {recorded!r}"
         assert recorded[0][0] == "/data/m0.mkv"
@@ -962,7 +957,7 @@ class TestFileResultEmissionFromMultiServerDispatch:
         def _cb(file_path, outcome_str, reason, worker, servers=None):
             recorded.append((file_path, outcome_str, reason, worker, servers or []))
 
-        set_file_result_callback(_cb)
+        set_file_result_callback(_cb, job_id="job-fr")
         try:
             with patch(
                 "media_preview_generator.processing.multi_server.process_canonical_path",
@@ -973,10 +968,11 @@ class TestFileResultEmissionFromMultiServerDispatch:
                     config=_config(),
                     registry=MagicMock(),
                     selected_gpus=[],
+                    job_id="job-fr",
                     label="full scan",
                 )
         finally:
-            set_file_result_callback(None)
+            set_file_result_callback(None, job_id="job-fr")
 
         assert len(recorded) == 1
         path, outcome, _reason, _worker, _servers = recorded[0]
@@ -984,571 +980,6 @@ class TestFileResultEmissionFromMultiServerDispatch:
         assert outcome == "failed", (
             "exception-swallowed branch must still produce a per-file row so the user "
             "can see which file blew up — without this the Files panel was just a counter."
-        )
-
-
-class TestWorkerCallbackEmissionFromMultiServerDispatch:
-    """D34 — multi-server dispatch path used to bypass the WorkerPool's
-    worker_callback so the Workers panel stayed empty for the entire run.
-    Synthetic worker rows derived from the executor's threads now flow
-    through the same callback the legacy path uses.
-    """
-
-    def test_worker_callback_fires_with_active_workers_during_run(self, tmp_path):
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [
-            (
-                cfg,
-                ProcessableItem(
-                    canonical_path=f"/data/m{i}.mkv",
-                    server_id="srv-a",
-                    title=f"Movie {i}",
-                ),
-            )
-            for i in range(3)
-        ]
-
-        snapshots: list[list[dict]] = []
-
-        def _wcb(workers_list):
-            snapshots.append(list(workers_list))
-
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            side_effect=_scan_then(
-                SimpleNamespace(
-                    publishers=[],
-                    canonical_path="/data/m.mkv",
-                    status=MultiServerStatus.PUBLISHED,
-                    message="",
-                )
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(),
-                registry=MagicMock(),
-                selected_gpus=[],
-                label="full scan",
-                worker_callback=_wcb,
-            )
-
-        # At least one snapshot must show a "processing" row — without
-        # the synthetic worker entries the panel would never have any
-        # rows at all during a multi-server scan.
-        assert any(any(w.get("status") == "processing" for w in snap) for snap in snapshots), (
-            f"no 'processing' worker entry in any snapshot: {snapshots!r}"
-        )
-        # Final state: every slot is back to idle (slots persist across
-        # the whole dispatch — they're not popped between items, that
-        # was the cause of the Workers-panel "flashing" bug). Slot
-        # *count* stays constant; only ``status`` and ``current_title``
-        # change in place.
-        assert snapshots[-1], "final snapshot must still carry the persistent slot rows"
-        assert all(w.get("status") == "idle" for w in snapshots[-1]), (
-            f"some slots ended in non-idle state: {snapshots[-1]!r}"
-        )
-        assert all(w.get("current_title") == "" for w in snapshots[-1]), (
-            "current_title must be cleared on idle so the panel doesn't keep showing a stale title"
-        )
-
-    def test_worker_callback_carries_current_title(self, tmp_path):
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [
-            (
-                cfg,
-                ProcessableItem(
-                    canonical_path="/data/named.mkv",
-                    server_id="srv-a",
-                    title="The Named Movie",
-                ),
-            )
-        ]
-
-        captured_titles: list[str] = []
-
-        def _wcb(workers_list):
-            for w in workers_list:
-                if w.get("current_title"):
-                    captured_titles.append(w["current_title"])
-
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            side_effect=_scan_then(
-                SimpleNamespace(
-                    publishers=[],
-                    canonical_path="/data/named.mkv",
-                    status=MultiServerStatus.PUBLISHED,
-                    message="",
-                )
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(),
-                registry=MagicMock(),
-                selected_gpus=[],
-                label="full scan",
-                worker_callback=_wcb,
-            )
-
-        assert "The Named Movie" in captured_titles, f"item title missing from worker snapshots: {captured_titles!r}"
-
-
-class TestFriendlyDeviceLabel:
-    """D34 — the raw gpu_info["name"] from lspci-style detection can be
-    extremely verbose (e.g. "Intel Corporation Raptor Lake-S GT1
-    [UHD Graphics 770] (rev 04)") which made the Workers-panel row
-    wrap and pushed the status badge around. The dispatcher's
-    _device_label helper extracts the bracketed user-recognisable
-    identifier when present.
-    """
-
-    def test_intel_long_name_collapses_to_bracketed_marketing_name(self, tmp_path):
-        # Verify by driving an actual dispatch with a synthetic gpu_info
-        # — the helper isn't exposed but we can read the worker_name it
-        # produces from the slot snapshot.
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [(cfg, ProcessableItem(canonical_path="/data/m.mkv", server_id="srv-a"))]
-        gpus = [
-            (
-                "INTEL",
-                "/dev/dri/renderD128",
-                {
-                    "workers": 1,
-                    "ffmpeg_threads": 2,
-                    "device": "/dev/dri/renderD128",
-                    "name": "Intel Corporation Raptor Lake-S GT1 [UHD Graphics 770] (rev 04)",
-                },
-            ),
-            (
-                "NVIDIA",
-                "cuda:0",
-                {"workers": 1, "ffmpeg_threads": 2, "device": "cuda:0", "name": "NVIDIA TITAN RTX"},
-            ),
-        ]
-        snapshots: list[list[dict]] = []
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[], canonical_path="/data/m.mkv", status=MultiServerStatus.PUBLISHED, message=""
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=0),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=lambda w: snapshots.append(list(w)),
-            )
-
-        worker_names = {w["worker_name"] for snap in snapshots for w in snap}
-        # NVIDIA name is short already — pass through unchanged.
-        assert any(n == "GPU Worker 1 (Intel UHD Graphics 770)" for n in worker_names), (
-            f"Intel label must collapse the verbose lspci string to the bracketed marketing name; got {worker_names!r}"
-        )
-        assert any(n == "GPU Worker 2 (NVIDIA TITAN RTX)" for n in worker_names), (
-            f"NVIDIA short label must pass through unchanged; got {worker_names!r}"
-        )
-
-    def test_no_brackets_falls_back_to_full_name(self, tmp_path):
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [(cfg, ProcessableItem(canonical_path="/data/m.mkv", server_id="srv-a"))]
-        gpus = [
-            ("NVIDIA", "cuda:0", {"workers": 1, "name": "NVIDIA GeForce RTX 4090"}),
-        ]
-        snapshots: list[list[dict]] = []
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[], canonical_path="/data/m.mkv", status=MultiServerStatus.PUBLISHED, message=""
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=0),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=lambda w: snapshots.append(list(w)),
-            )
-        worker_names = {w["worker_name"] for snap in snapshots for w in snap}
-        # Audit fix — was loose `"NVIDIA GeForce RTX 4090" in n` which would
-        # pass even if the formatter dropped the "GPU Worker N (...)" prefix.
-        # Mirror the rigour of test_intel_long_name_collapses_to_bracketed_marketing_name
-        # at L933 by pinning the full label format.
-        assert "GPU Worker 1 (NVIDIA GeForce RTX 4090)" in worker_names, (
-            f"NVIDIA fallback label must use full 'GPU Worker N (full name)' format; got {worker_names!r}"
-        )
-
-
-class TestParallelismRespectsPerDeviceWorkerCount:
-    """D34 — the multi-server dispatcher used to read ``workers`` off
-    each gpu_info entry via ``getattr(g[2], 'workers', 1)``. But
-    ``g[2]`` is the dict that ``_build_selected_gpus`` constructs with
-    ``info["workers"] = workers`` — a *key*, not an attribute. ``getattr``
-    on a dict returns the default unless the dict has an attribute with
-    that name (it doesn't), so a user with two GPUs each configured for
-    2 workers got parallelism=2 instead of 4. Live reproducer on the
-    canary: Workers panel only ever showed 2 rows during a Plex Movies
-    scan despite Settings → GPU listing 2+2.
-    """
-
-    @staticmethod
-    def _make_gpu(device: str, workers: int, gpu_type: str = "NVIDIA") -> tuple:
-        # Mirror what _build_selected_gpus produces — a plain dict, not
-        # a SimpleNamespace. The previous test that used SimpleNamespace
-        # inadvertently *worked around* the bug because getattr does
-        # find attributes on SimpleNamespace.
-        return (gpu_type, device, {"workers": workers, "ffmpeg_threads": 2, "device": device})
-
-    def test_per_device_workers_count_expands_into_real_concurrency(self, tmp_path):
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/data/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(8)
-        ]
-
-        snapshots: list[list[dict]] = []
-
-        def _wcb(workers_list):
-            snapshots.append(list(workers_list))
-
-        # 2 NVIDIA workers + 2 Intel workers — exactly the canary config.
-        gpus = [
-            self._make_gpu("cuda:0", workers=2, gpu_type="NVIDIA"),
-            self._make_gpu("/dev/dri/renderD128", workers=2, gpu_type="INTEL"),
-        ]
-
-        # The mock has to sleep long enough that multiple threads are
-        # alive concurrently — otherwise pool.map serialises by accident
-        # because each item finishes before the next thread is spawned.
-        # 50ms × 8 items = ~100ms wall on parallelism=4.
-        import time as _time
-
-        def _slow(canonical_path, **kwargs):
-            # Scan pass returns instantly so every item proceeds to a
-            # (capped) generation call — that's where the concurrency this
-            # test measures actually happens.
-            if kwargs.get("check_only"):
-                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
-            _time.sleep(0.05)
-            return SimpleNamespace(
-                publishers=[],
-                canonical_path=canonical_path,
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            )
-
-        # Disable the snapshot throttle so per-item transitions are
-        # observable in this 100 ms test (production cadence is 1 Hz
-        # — see ``_WORKER_EMIT_THROTTLE_S``). Throttle is irrelevant
-        # to what this test is checking (peak concurrent slot
-        # transitions); keeping it on would mask the "all 4 active
-        # at once" moment behind the throttle window.
-        with (
-            patch("media_preview_generator.jobs.orchestrator._WORKER_EMIT_THROTTLE_S", 0.0),
-            patch(
-                "media_preview_generator.processing.multi_server.process_canonical_path",
-                side_effect=_slow,
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=0),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=_wcb,
-            )
-
-        # Slot count is always 4 (slots persist across the whole
-        # dispatch — they don't pop between items, that was the
-        # "Workers panel flashing" bug). What we actually need to
-        # assert is that all 4 slots transition to "processing"
-        # *concurrently* at some point.
-        peak_processing = max(
-            (sum(1 for w in snap if w.get("status") == "processing") for snap in snapshots),
-            default=0,
-        )
-        assert peak_processing == 4, (
-            f"Configured 2 NVIDIA + 2 Intel = 4 worker slots; observed peak "
-            f"concurrently-processing workers = {peak_processing}. The Workers "
-            f"panel only showed that many active rows on the canary."
-        )
-
-        # Slot rows persist for the whole dispatch — every snapshot
-        # must always carry exactly 4 rows (not 0..4 oscillating).
-        # That's the fix for the "rows flash on/off" bug.
-        slot_counts = sorted({len(s) for s in snapshots})
-        assert slot_counts == [4], (
-            f"Slot rows must persist (always present, only status flips). Observed snapshot lengths: {slot_counts!r}"
-        )
-
-        # Each slot has a stable worker_id (1..N) for the lifetime of
-        # the dispatch — used by the Files panel to attribute each row
-        # to the worker that handled it.
-        all_ids: set[int] = set()
-        for snap in snapshots:
-            for w in snap:
-                all_ids.add(w.get("worker_id"))
-        assert all_ids == {1, 2, 3, 4}, f"slot ids must be the stable 1..N range, got {all_ids!r}"
-
-        # Each slot's friendly name follows the legacy WorkerPool
-        # format ("GPU Worker N (Device)") so the multi-server panel
-        # rows look identical to the legacy panel rows. We used the
-        # device path here ("cuda:0") since the test fixture didn't
-        # set a name; production passes a real device name through
-        # the same formatter.
-        worker_names = sorted({w.get("worker_name", "") for snap in snapshots for w in snap})
-        assert any("GPU Worker" in n and "cuda:0" in n for n in worker_names), (
-            f"NVIDIA slot label missing the 'GPU Worker N (cuda:0)' shape; got {worker_names!r}"
-        )
-        assert any("GPU Worker" in n and "renderD128" in n for n in worker_names), (
-            f"Intel slot label missing the 'GPU Worker N (renderD128)' shape; got {worker_names!r}"
-        )
-
-    def test_workers_zero_treated_as_one(self, tmp_path):
-        """A pathological workers=0 in gpu_config used to silently zero
-        out a device's contribution; clamp to ≥1 so users can't hide a
-        device behind a typo."""
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [(cfg, ProcessableItem(canonical_path="/data/x.mkv", server_id="srv-a"))]
-
-        snapshots: list[list[dict]] = []
-        gpus = [self._make_gpu("cuda:0", workers=0)]
-
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[],
-                canonical_path="/data/x.mkv",
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=lambda w: snapshots.append(list(w)),
-            )
-
-        # Pin the clamp behaviour, not just "something happened". The
-        # orchestrator's _read_workers_count must turn workers=0 into
-        # exactly 1 GPU slot for the cuda:0 device. The previous
-        # ``any(snapshots)`` check would still pass if the clamp were
-        # silently dropped (because the cpu_threads=1 default produces a
-        # CPU slot regardless, masking the missing GPU slot).
-        assert snapshots, "no worker snapshots emitted at all"
-        last_snap = snapshots[-1]
-        gpu_slots_for_device = [
-            w for w in last_snap if w.get("worker_type") == "GPU" and w.get("gpu_device") == "cuda:0"
-        ]
-        assert len(gpu_slots_for_device) == 1, (
-            f"workers=0 must clamp to exactly 1 GPU slot for cuda:0; got {len(gpu_slots_for_device)} "
-            f"(full snapshot={last_snap!r})"
-        )
-
-    def test_slot_rows_persist_across_items_no_flashing(self, tmp_path):
-        """User-reported bug: Workers panel rows flashed on/off as
-        items completed. Root cause was per-item pop-on-finally + add-on-
-        next-pickup. Fix: pre-allocated slots that flip status in place
-        and never pop. This test asserts both invariants:
-        - every snapshot has the same number of rows (no flashing)
-        - the same worker_id keeps the same worker_name across snapshots
-          (no identity churn between items)
-        """
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/d/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(8)
-        ]
-        snapshots: list[list[dict]] = []
-        gpus = [self._make_gpu("cuda:0", workers=2)]
-
-        import time as _time
-
-        def _slow(canonical_path, **kwargs):
-            _time.sleep(0.03)
-            return SimpleNamespace(
-                publishers=[],
-                canonical_path=canonical_path,
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            )
-
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            side_effect=_slow,
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=0),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=lambda w: snapshots.append(list(w)),
-            )
-
-        # Invariant 1 — slot count never changes during the run.
-        # Pre-fix: lengths oscillated [0, 1, 2, 1, 0, 1, 2, …] as
-        # workers popped in finally blocks and re-added on the next
-        # item pickup; the panel rendered that as rows blinking.
-        sizes = {len(s) for s in snapshots}
-        assert sizes == {2}, (
-            f"Workers panel rows must persist across items (no flashing); observed snapshot sizes: {sorted(sizes)!r}"
-        )
-
-        # Invariant 2 — each stable worker_id keeps the same friendly
-        # name and same gpu_device for the entire job. If a slot's
-        # name changed mid-run the panel would show "row swap" which
-        # is the same UX as a flash.
-        identity_by_id: dict[int, tuple[str, str | None]] = {}
-        for snap in snapshots:
-            for w in snap:
-                wid = w["worker_id"]
-                ident = (w["worker_name"], w.get("gpu_device"))
-                if wid in identity_by_id:
-                    assert identity_by_id[wid] == ident, (
-                        f"Slot {wid} identity changed mid-run from {identity_by_id[wid]!r} to {ident!r}"
-                    )
-                else:
-                    identity_by_id[wid] = ident
-        assert set(identity_by_id) == {1, 2}, identity_by_id
-
-
-class TestHotReloadWorkerCount:
-    """User report: bumped NVIDIA workers 2→3 in Settings while a job
-    was running, only saw the 3rd row after stopping + refreshing.
-    "IT SHould live update workers on changing the number of them even
-    in middle of job. it usef to work" — fix is the periodic settings
-    poller inside ``_dispatch_processable_items``.
-    """
-
-    @staticmethod
-    def _make_gpu(device: str, workers: int, gpu_type: str = "NVIDIA", name: str | None = None) -> tuple:
-        return (
-            gpu_type,
-            device,
-            {
-                "workers": workers,
-                "ffmpeg_threads": 2,
-                "device": device,
-                "name": name or "NVIDIA TITAN RTX",
-            },
-        )
-
-    def test_growing_gpu_workers_mid_job_adds_a_slot(self, tmp_path):
-        """Bumps NVIDIA workers 2→3 mid-job via the settings_manager
-        the poller reads from. Asserts a third slot appears in the
-        snapshots (not just at the end — while items are still
-        processing)."""
-        import time as _time
-
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        # Enough items that we definitely have work in flight when we
-        # bump the setting (each item sleeps ~80ms below).
-        # 60 items × 200ms ÷ 2 workers ≈ 6s wall clock, plenty of time
-        # for the 1.5s poller to tick after the bump fires at t=2s.
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/d/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(60)
-        ]
-        snapshots: list[list[dict]] = []
-        gpus = [self._make_gpu("cuda:0", workers=2, name="NVIDIA TITAN RTX")]
-
-        def _slow(canonical_path, **kwargs):
-            # Scan pass returns instantly; only generation calls hold a slot
-            # long enough for the poller to observe a grown worker count.
-            if kwargs.get("check_only"):
-                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
-            _time.sleep(0.2)
-            return SimpleNamespace(
-                publishers=[],
-                canonical_path=canonical_path,
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            )
-
-        # Mutable settings stub so we can flip the worker count after
-        # a delay — same shape the poller reads from
-        # `get_settings_manager()` in production.
-        gpu_config_state = [{"device": "cuda:0", "type": "NVIDIA", "enabled": True, "workers": 2, "ffmpeg_threads": 2}]
-
-        class _FakeSettings:
-            @property
-            def gpu_config(self):
-                return gpu_config_state
-
-            cpu_threads = 0
-
-        def _bump_after_delay():
-            _time.sleep(2.0)  # poll interval is 1.5s; give it a tick to read the original then bump
-            gpu_config_state[0]["workers"] = 3
-
-        import threading as _threading
-
-        bumper = _threading.Thread(target=_bump_after_delay, daemon=True)
-        bumper.start()
-
-        with (
-            patch(
-                "media_preview_generator.processing.multi_server.process_canonical_path",
-                side_effect=_slow,
-            ),
-            patch("media_preview_generator.web.settings_manager.get_settings_manager", return_value=_FakeSettings()),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=0),
-                registry=MagicMock(),
-                selected_gpus=gpus,
-                label="full scan",
-                worker_callback=lambda w: snapshots.append(list(w)),
-            )
-
-        # Snapshot lengths over the run: must include 2 (initial) AND
-        # at least one snapshot with 3 (after the poller picked up the
-        # bump). If hot-reload is broken we'd only ever see 2.
-        max_seen = max(len(s) for s in snapshots)
-        assert max_seen >= 3, (
-            f"Settings bump 2→3 was not picked up mid-job; max concurrent slot count "
-            f"observed = {max_seen}. Snapshot timeline (lengths): {[len(s) for s in snapshots]!r}"
-        )
-        # And at least one of the post-bump snapshots must have 3
-        # slots ALL with the new "GPU Worker N (NVIDIA TITAN RTX)" label
-        # — not just three random slots.
-        big_snapshots = [s for s in snapshots if len(s) >= 3]
-        assert big_snapshots, "no snapshot with ≥3 slots — hot-reload didn't take effect"
-        sample = big_snapshots[-1]
-        names = sorted(s["worker_name"] for s in sample)
-        assert all("NVIDIA TITAN RTX" in n and "GPU Worker" in n for n in names), (
-            f"new slot didn't get the standard 'GPU Worker N (NVIDIA TITAN RTX)' label; got {names!r}"
         )
 
 
@@ -1968,8 +1399,9 @@ class TestRealEndToEndMultiServerFullScan:
 
             counts = _run_full_scan_multi_server(cfg_obj, selected_gpus=[])
 
-        # The real pipeline ran end-to-end and recorded one publish.
-        assert counts.get("published", 0) == 1, counts
+        # The real pipeline ran end-to-end and generated one file (per-file
+        # counts under the unified dispatcher: one generated, not one publish).
+        assert counts.get("generated", 0) == 1, counts
         # compute_output_paths is called three times in the real post-#243
         # flow: once by the cheap ``check_only`` scan pass's freshness probe
         # (decoupled from the generation permit), then — on the generation
@@ -2523,129 +1955,6 @@ class TestFullScanUsesSetPublishersNotAppend:
         )
 
 
-class TestProgressEmissionInCompletionOrder:
-    """Job 9eb79d9c regression — progress numerator stuck at low values
-    while items completed in the background, then jumped to the final
-    count the moment the user stopped the job.
-
-    Root cause: ``_dispatch_processable_items`` consumed worker results
-    via ``ThreadPoolExecutor.map``, which yields results in **submission
-    order**. A slow item near the front of the queue blocked the
-    progress increment for every faster item behind it — workers were
-    completing in parallel but the for-loop sat on the head of the
-    iterator, so the ``progress_callback`` (and its SocketIO emit) never
-    fired until the slow item completed.
-
-    Fix: switch to ``submit`` + ``as_completed`` so progress reflects
-    actual completion order, with the same single-thread consumption
-    semantics the existing publisher fold relies on.
-    """
-
-    def test_fast_items_report_progress_before_slow_head_item_completes(self, tmp_path):
-        import threading
-        import time as _time
-
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        # 5 items; item 0 will block, items 1-4 return instantly. With
-        # 5 CPU worker slots all five run in parallel so the head item
-        # cannot starve out the rest.
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/data/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(5)
-        ]
-
-        release_head = threading.Event()
-        progress_lock = threading.Lock()
-        progress_calls: list[tuple[int, int, str]] = []
-        four_fast_done = threading.Event()
-
-        def _record_progress(processed: int, total: int, msg: str) -> None:
-            with progress_lock:
-                progress_calls.append((processed, total, msg))
-                # Banner is (0, 5); fast items push processed up to 4.
-                if processed >= 4:
-                    four_fast_done.set()
-
-        def _fake_pcp(*, canonical_path, **kwargs):
-            if canonical_path == "/data/m0.mkv":
-                # Block until the test confirms the four fast items
-                # have already reported progress. If the dispatcher
-                # serialises on submission order, this wait times out
-                # and the test fails before the event is released.
-                if not release_head.wait(timeout=5.0):
-                    # Test will fail below; let the dispatcher return.
-                    pass
-            return SimpleNamespace(
-                publishers=[],
-                canonical_path=canonical_path,
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            )
-
-        dispatch_done = threading.Event()
-        dispatch_result: dict = {}
-
-        def _run_dispatch():
-            try:
-                with patch(
-                    "media_preview_generator.processing.multi_server.process_canonical_path",
-                    side_effect=_fake_pcp,
-                ):
-                    dispatch_result["counts"] = _dispatch_processable_items(
-                        items=items,
-                        config=_config(cpu_threads=5),
-                        registry=MagicMock(),
-                        selected_gpus=[],
-                        progress_callback=_record_progress,
-                        label="full scan",
-                    )
-            finally:
-                dispatch_done.set()
-
-        runner = threading.Thread(target=_run_dispatch, name="dispatch-under-test", daemon=True)
-        runner.start()
-        try:
-            # Give the four fast items up to 2.5 s to report progress
-            # while item 0 is still parked on the event. With pool.map
-            # this never happens — the for-loop is stuck at submission
-            # index 0 waiting on the slow item. With as_completed,
-            # fast items reach the consumer immediately and the
-            # callback fires for each one in well under a second.
-            assert four_fast_done.wait(timeout=2.5), (
-                f"Expected progress_callback to fire for the four fast items while item 0 was "
-                f"still blocked. Observed progress events so far: {progress_calls!r}. "
-                f"Submission-order consumption (pool.map) starves the progress counter when an "
-                f"early item is slow — the symptom job 9eb79d9c reported."
-            )
-
-            # Sanity: confirm there is at least one fast-item progress
-            # entry with processed in (1..4) — i.e. the assert above
-            # didn't get satisfied by some other emit path.
-            with progress_lock:
-                fast_progress = [p for p, _t, _m in progress_calls if 1 <= p <= 4]
-            assert fast_progress, (
-                f"No 'processed in 1..4' events observed before item 0 unblocked. Calls so far: {progress_calls!r}"
-            )
-        finally:
-            release_head.set()
-            runner.join(timeout=5.0)
-            assert dispatch_done.is_set(), "dispatch thread did not finish within timeout"
-
-        # Final progress should reflect every item.
-        with progress_lock:
-            final_processed = max((p for p, _t, _m in progress_calls), default=0)
-        assert final_processed == 5, (
-            f"Final progress count must equal total items (5); got {final_processed}. All calls: {progress_calls!r}"
-        )
-
-        # And the dispatcher returned a successful counts dict — no
-        # exception swallowed by the background thread.
-        assert dispatch_result.get("counts") is not None
-        _time.sleep(0)  # let any daemon poller threads finish their tick
-
-
 class TestEnumerationFailurePropagatesAsWarning:
     """Job b6deeac3 regression: Jellyfin's /Items query timed out on a
     118k-item Shows library (transient — same query ran in 0.2s minutes
@@ -2940,160 +2249,3 @@ class TestWorkerFFmpegStartedFlag:
                         f"_release_slot must reset the flag between items so item 2 doesn't "
                         f"inherit item 1's flipped state. Snapshot: {w!r}"
                     )
-
-
-class TestWorkerSnapshotEmitThrottle:
-    """Job 8cd02fa6 regression: a 10k-item Jellyfin full scan with mostly
-    "already fresh — skip FFmpeg" no-op items completes each item in ~50 ms.
-    With 4 workers that's ~80 items/sec × 2 transitions (claim + release) =
-    ~160 ``worker_update`` SocketIO emits per second. The browser event
-    loop can't keep up, the dashboard Workers panel never renders cleanly,
-    and the user sees an empty panel despite the backend having full
-    per-worker speed/eta data.
-
-    Plex's legacy ``WorkerPool`` already throttles emits to ≈1 Hz
-    (``worker.py:1245`` — ``if current_time - last_worker_update >= 1.0``).
-    The multi-server dispatcher should do the same. The original
-    intent is even documented in ``orchestrator.py``'s comment block
-    claiming the path is ``1Hz throttled`` — but the actual code only
-    throttles the periodic poller, not per-item transitions.
-    """
-
-    def test_snapshot_emits_are_throttled_under_fast_item_flood(self, tmp_path):
-        import time as _time
-
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        N = 200
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/data/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(N)
-        ]
-
-        snapshots: list = []
-        start = _time.monotonic()
-
-        def _wcb(workers_list):
-            snapshots.append((_time.monotonic() - start, list(workers_list)))
-
-        with patch(
-            "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[],
-                canonical_path="/x",
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            ),
-        ):
-            _dispatch_processable_items(
-                items=items,
-                config=_config(cpu_threads=4),
-                registry=MagicMock(),
-                selected_gpus=[],
-                label="full scan",
-                worker_callback=_wcb,
-            )
-
-        elapsed = _time.monotonic() - start
-        # Budget: ~1 emit/sec on the throttled path, plus the forced
-        # leading emit at dispatch start and the forced final emit at
-        # dispatch end. A 200-no-op-item run completes in well under
-        # 1 second on any modern box, so the realistic ceiling is
-        # leading + trailing-on-close + slack = ~5.
-        expected_max = max(6, int(elapsed) + 4)
-        assert len(snapshots) <= expected_max, (
-            f"Expected ≤{expected_max} worker snapshots in {elapsed:.2f}s under 1 Hz throttle; "
-            f"got {len(snapshots)}. Without throttle a 200-item fast-no-op dispatch fires "
-            f"~400+ emits — that's the flood pattern job 8cd02fa6 reproduced "
-            f"(dashboard Workers panel never settled long enough to render)."
-        )
-        # And the throttle must not be so aggressive it suppresses everything —
-        # the user still needs to see SOMETHING in the panel.
-        non_empty_snapshots = [snap for _, snap in snapshots if snap]
-        assert non_empty_snapshots, (
-            f"Throttle suppressed every emit. Got {len(snapshots)} snapshot(s), "
-            f"all empty. The leading-edge emit at dispatch start must always fire."
-        )
-
-    def test_snapshot_emits_continue_during_long_running_items(self, tmp_path):
-        """A scan with slow items (4K FFmpeg passes that take 30s+) must still
-        produce periodic snapshots so the user sees speed/ETA tick forward. The
-        throttle limits cadence but cannot starve the user — the
-        ``_poller_loop``'s 1.5 s heartbeat passes the 1 Hz throttle naturally.
-
-        Asserts via timestamps so the test would actually fail if someone
-        removed the poller's ``_emit_worker_snapshot()`` call — the
-        initial force emit and the leading-edge claim emit both land in
-        the first ~100 ms, so counting "snapshots so far" can't tell
-        the difference between "poller fired" and "only initial fired."
-        """
-        import threading as _threading
-        import time as _time
-
-        from media_preview_generator.jobs.orchestrator import _dispatch_processable_items
-        from media_preview_generator.processing.multi_server import MultiServerStatus
-
-        cfg = _server_config("srv-a", ServerType.JELLYFIN)
-        items = [
-            (cfg, ProcessableItem(canonical_path=f"/data/m{i}.mkv", server_id="srv-a", title=f"M{i}")) for i in range(2)
-        ]
-
-        snapshots: list[tuple[float, list[dict]]] = []
-        release = _threading.Event()
-
-        start = _time.monotonic()
-
-        def _wcb(workers_list):
-            snapshots.append((_time.monotonic() - start, list(workers_list)))
-
-        def _slow(canonical_path, **kwargs):
-            release.wait(timeout=6.0)
-            return SimpleNamespace(
-                publishers=[],
-                canonical_path=canonical_path,
-                status=MultiServerStatus.PUBLISHED,
-                message="",
-            )
-
-        done = _threading.Event()
-
-        def _run():
-            try:
-                with patch(
-                    "media_preview_generator.processing.multi_server.process_canonical_path",
-                    side_effect=_slow,
-                ):
-                    _dispatch_processable_items(
-                        items=items,
-                        config=_config(cpu_threads=2),
-                        registry=MagicMock(),
-                        selected_gpus=[],
-                        label="full scan",
-                        worker_callback=_wcb,
-                    )
-            finally:
-                done.set()
-
-        runner = _threading.Thread(target=_run, daemon=True)
-        runner.start()
-        try:
-            # Capture snapshots arriving AFTER t=2.0 — past the initial
-            # force emit (t≈0) and the leading-edge claim emit (t≈0).
-            # Only the 1.5 s poller heartbeat can populate that window
-            # while items are blocked.
-            _time.sleep(3.2)
-            late_snapshots = [snap for ts, snap in snapshots if ts >= 2.0]
-        finally:
-            release.set()
-            assert done.wait(timeout=5.0)
-            runner.join(timeout=5.0)
-
-        assert late_snapshots, (
-            f"No snapshots arrived between t=2.0 s and t=3.2 s while both items "
-            f"were blocked. Only the poller's 1.5 s heartbeat can produce them "
-            f"in that window — if this assertion ever regresses, the poller's "
-            f"``_emit_worker_snapshot()`` call has been removed. All observed "
-            f"snapshots (ts, slot_count): "
-            f"{[(round(ts, 2), len(snap)) for ts, snap in snapshots]}"
-        )

--- a/tests/test_full_scan_multi_server.py
+++ b/tests/test_full_scan_multi_server.py
@@ -47,6 +47,26 @@ def _server_config(server_id, server_type=ServerType.JELLYFIN):
     )
 
 
+def _scan_then(result):
+    """``process_canonical_path`` side_effect for the post-#243 two-phase flow.
+
+    The full-scan dispatcher now runs a cheap ``check_only=True`` pass on each
+    item before it claims a generation slot. Tests that exercise the
+    generation path (slot claim, worker snapshots, FFmpeg-started flag) must
+    return ``NEEDS_GENERATION`` on that scan pass so the item proceeds to a
+    real generation call, which then returns ``result`` (or ``result(**kwargs)``
+    when a callable is supplied).
+    """
+    from media_preview_generator.processing.multi_server import MultiServerStatus
+
+    def _side_effect(*args, **kwargs):
+        if kwargs.get("check_only"):
+            return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+        return result(*args, **kwargs) if callable(result) else result
+
+    return _side_effect
+
+
 class TestMultiServerFullScan:
     def test_no_servers_configured_returns_zero_counts(self, tmp_path):
         """No servers → zero counts AND no dispatch attempts.
@@ -998,11 +1018,13 @@ class TestWorkerCallbackEmissionFromMultiServerDispatch:
 
         with patch(
             "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[],
-                canonical_path="/data/m.mkv",
-                status=MultiServerStatus.PUBLISHED,
-                message="",
+            side_effect=_scan_then(
+                SimpleNamespace(
+                    publishers=[],
+                    canonical_path="/data/m.mkv",
+                    status=MultiServerStatus.PUBLISHED,
+                    message="",
+                )
             ),
         ):
             _dispatch_processable_items(
@@ -1058,11 +1080,13 @@ class TestWorkerCallbackEmissionFromMultiServerDispatch:
 
         with patch(
             "media_preview_generator.processing.multi_server.process_canonical_path",
-            return_value=SimpleNamespace(
-                publishers=[],
-                canonical_path="/data/named.mkv",
-                status=MultiServerStatus.PUBLISHED,
-                message="",
+            side_effect=_scan_then(
+                SimpleNamespace(
+                    publishers=[],
+                    canonical_path="/data/named.mkv",
+                    status=MultiServerStatus.PUBLISHED,
+                    message="",
+                )
             ),
         ):
             _dispatch_processable_items(
@@ -1218,6 +1242,11 @@ class TestParallelismRespectsPerDeviceWorkerCount:
         import time as _time
 
         def _slow(canonical_path, **kwargs):
+            # Scan pass returns instantly so every item proceeds to a
+            # (capped) generation call — that's where the concurrency this
+            # test measures actually happens.
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
             _time.sleep(0.05)
             return SimpleNamespace(
                 publishers=[],
@@ -1454,6 +1483,10 @@ class TestHotReloadWorkerCount:
         gpus = [self._make_gpu("cuda:0", workers=2, name="NVIDIA TITAN RTX")]
 
         def _slow(canonical_path, **kwargs):
+            # Scan pass returns instantly; only generation calls hold a slot
+            # long enough for the poller to observe a grown worker count.
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
             _time.sleep(0.2)
             return SimpleNamespace(
                 publishers=[],
@@ -1937,11 +1970,13 @@ class TestRealEndToEndMultiServerFullScan:
 
         # The real pipeline ran end-to-end and recorded one publish.
         assert counts.get("published", 0) == 1, counts
-        # compute_output_paths is called twice in the real flow: once by
-        # the pre-FFmpeg "are outputs fresh?" probe, once inside
-        # _publish_one for the publish path. Both must see the same
+        # compute_output_paths is called three times in the real post-#243
+        # flow: once by the cheap ``check_only`` scan pass's freshness probe
+        # (decoupled from the generation permit), then — on the generation
+        # call — once more by that call's own freshness probe and once inside
+        # _publish_one for the publish path. All three must see the same
         # canonical path and the same bare item id — that's the D31 contract.
-        assert len(captured_compute_calls) == 2
+        assert len(captured_compute_calls) == 3
         assert len(captured_publish_calls) == 1
 
         for call in captured_compute_calls:
@@ -2752,6 +2787,10 @@ class TestWorkerFFmpegStartedFlag:
             snapshots.append(list(workers_list))
 
         def _pcp_two_phase(*, canonical_path, progress_callback=None, **kwargs):
+            # Scan pass returns instantly so the item claims a generation slot
+            # below (where the ffmpeg_started flag transitions are exercised).
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
             # Phase 1 — pre-FFmpeg setup (no progress yet). The poller
             # heartbeat fires every 1.5 s, so 1.7 s here guarantees at
             # least one snapshot lands with ffmpeg_started=False.
@@ -2839,6 +2878,10 @@ class TestWorkerFFmpegStartedFlag:
         call_count = {"n": 0}
 
         def _pcp(*, canonical_path, progress_callback=None, **kwargs):
+            # Scan pass returns instantly and does NOT advance call_count, so
+            # call_count tracks generation calls only (item 1 then item 2).
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
             call_count["n"] += 1
             if call_count["n"] == 1:
                 # Item 1 — real FFmpeg pass; flips the flag True.

--- a/tests/test_job_dispatcher.py
+++ b/tests/test_job_dispatcher.py
@@ -40,6 +40,20 @@ def _make_gpu_list(n=1):
 
 
 def _fake_process_item(*args, **kwargs):
+    # Post-#243 the dispatcher runs a check_only scan pass first. Report
+    # NEEDS_GENERATION there so the item flows on to a processing worker
+    # (where these tests assert worker/dispatch behaviour); the processing
+    # call then returns a normal generated result.
+    if kwargs.get("check_only"):
+        from media_preview_generator.processing.multi_server import (
+            MultiServerResult,
+            MultiServerStatus,
+        )
+
+        return MultiServerResult(
+            canonical_path=kwargs.get("canonical_path", "") or "",
+            status=MultiServerStatus.NEEDS_GENERATION,
+        )
     time.sleep(0.02)
     return _ms("generated")
 
@@ -88,8 +102,12 @@ class TestJobTracker:
             config=_make_config(),
             registry=MagicMock(),
         )
-        assert len(tracker.item_queue) == 3
+        # Items now enter the checking queue first (item_queue receives only
+        # items the check stage flags as needing FFmpeg).
+        assert len(tracker.check_queue) == 3
+        assert len(tracker.item_queue) == 0
         tracker.cancel()
+        assert len(tracker.check_queue) == 0
         assert len(tracker.item_queue) == 0
         assert tracker.cancelled
         assert tracker.done_event.is_set()

--- a/tests/test_job_runner_completion.py
+++ b/tests/test_job_runner_completion.py
@@ -160,14 +160,13 @@ class TestClassifyJobCompletion:
         )
         assert result == "error"
 
-    def test_retry_job_with_leftover_paths_is_hard_failure(self):
-        """A retry job that exits with unresolved retry paths (and didn't
-        spawn another retry) is a terminal failure — the user's webhook
-        never got served.
+    def test_retry_exhausted_with_no_successes_is_hard_failure(self):
+        """A retry chain that exhausts AND served nothing (no previews made)
+        is a terminal failure — the user's webhook never got served.
         """
         result = _classify_job_completion(
             failures=[],
-            outcome={"generated": 1},
+            outcome={"generated": 0, "skipped_file_not_found": 1},
             is_retry=True,
             retry_paths=["/still-missing.mkv"],
             spawned_retry_id=None,
@@ -175,6 +174,25 @@ class TestClassifyJobCompletion:
             resolved_count=1,
         )
         assert result == "error"
+
+    def test_retry_exhausted_with_successes_is_warning_not_failure(self):
+        """A retry chain that exhausted but still GENERATED previews is a
+        partial failure (amber), not a total failure (red). Regression: job
+        67f7bf2a generated 11 previews with 0 hard failures but showed red
+        "Failed" purely because the chain couldn't register a few genuinely-
+        missing files. retry_exhausted must respect success_total like every
+        other gate.
+        """
+        result = _classify_job_completion(
+            failures=[],
+            outcome={"generated": 11, "skipped_file_not_found": 4},
+            is_retry=True,
+            retry_paths=["/still-missing-1.mkv", "/still-missing-2.mkv"],
+            spawned_retry_id=None,
+            total_paths=15,
+            resolved_count=15,
+        )
+        assert result == "warning"
 
     def test_all_not_found_without_spawn_is_hard_failure(self):
         """Every file Plex resolved was missing on disk AND no retry was

--- a/tests/test_orchestrator_cpu_fallback.py
+++ b/tests/test_orchestrator_cpu_fallback.py
@@ -38,15 +38,23 @@ from media_preview_generator.servers.base import ServerConfig, ServerType
 MODULE = "media_preview_generator.jobs.orchestrator"
 
 
-def _config(cpu_threads: int = 1):
+def _config(cpu_threads: int = 1, gpu_threads: int = 1):
+    # gpu_threads defaults to 1 because these tests pass a GPU in
+    # selected_gpus and exercise the GPU→CPU fallback. The unified dispatcher
+    # sizes GPU workers from config.gpu_threads (like the existing
+    # _create_worker_pool), so the count must match the GPU passed — in
+    # production config.gpu_threads and selected_gpus derive from the same
+    # gpu_config, so they're always consistent.
     return SimpleNamespace(
-        gpu_threads=0,
+        gpu_threads=gpu_threads,
         cpu_threads=cpu_threads,
+        scan_workers=0,
         working_tmp_folder="/tmp/work",
         plex_url="",
         plex_token="",
         webhook_paths=None,
         server_id_filter=None,
+        regenerate_thumbnails=False,
     )
 
 
@@ -217,8 +225,8 @@ class TestOrchestratorCpuFallback:
         assert counts.get(ProcessingResult.FAILED.value, 0) == 0, (
             f"successful CPU fallback must NOT be counted as failed; counts={counts}"
         )
-        assert counts.get("published", 0) == 1, (
-            f"successful CPU fallback must surface as a published item; counts={counts}"
+        assert counts.get("generated", 0) == 1, (
+            f"successful CPU fallback must surface as a generated item; counts={counts}"
         )
 
     def test_cpu_fallback_failure_is_marked_failed_and_does_not_propagate(self, tmp_path):

--- a/tests/test_orchestrator_cpu_fallback.py
+++ b/tests/test_orchestrator_cpu_fallback.py
@@ -107,24 +107,39 @@ class TestOrchestratorCpuFallback:
 
         Without this row, a refactor that always re-runs on CPU would
         silently double the workload on healthy items.
+
+        Post-#243 the full-scan path runs a ``check_only`` scan pass first;
+        an item that needs work reports NEEDS_GENERATION and then takes
+        exactly one generation call (the GPU attempt). No CPU fallback.
         """
         cfg, registry_mock, proc = self._setup_one_item_dispatch()
+
+        def pcp(**kwargs):
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            return _success_result()
+
+        mock_pcp = MagicMock(side_effect=pcp)
 
         with (
             patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
             patch("media_preview_generator.servers.ServerRegistry") as mock_registry,
             patch("media_preview_generator.processing.get_processor_for", return_value=proc),
-            patch("media_preview_generator.processing.multi_server.process_canonical_path") as mock_pcp,
+            patch("media_preview_generator.processing.multi_server.process_canonical_path", mock_pcp),
         ):
             mock_sm.return_value.get.return_value = [{"id": "srv-a", "type": "jellyfin", "enabled": True}]
             mock_registry.from_settings.return_value = registry_mock
-            mock_pcp.return_value = _success_result()
 
             _run_full_scan_multi_server(_config(), selected_gpus=[("NVIDIA", "/dev/nvidia0", {})])
 
-        assert mock_pcp.call_count == 1, (
-            f"GPU success path must call process_canonical_path exactly once, got {mock_pcp.call_count}"
+        # Exactly one GENERATION call (the GPU attempt). The scan-phase
+        # check_only call(s) don't count as work and must not trigger a
+        # CPU fallback.
+        gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
+        assert len(gen_calls) == 1, (
+            f"GPU success must produce exactly one generation call (no CPU re-run), got {len(gen_calls)}"
         )
+        assert gen_calls[0].kwargs["gpu"] == "NVIDIA"
 
     def test_gpu_codec_error_falls_back_to_cpu_with_gpu_none(self, tmp_path):
         """GPU raises CodecNotSupportedError → second call must run with gpu=None.
@@ -135,16 +150,21 @@ class TestOrchestratorCpuFallback:
         """
         cfg, registry_mock, proc = self._setup_one_item_dispatch()
 
-        # Fail on first call (GPU), succeed on second (CPU fallback).
-        # Asserting the kwargs of BOTH calls ensures the fix forwards
-        # the right gpu= value — per .claude/rules/testing.md the test
-        # must lock in the contract the SUT controls (gpu=None on retry),
-        # not just that fallback was attempted.
-        outcomes = [
-            CodecNotSupportedError("GPU processing failed (hardware accelerator runtime error) for /data/anime.mkv"),
-            _success_result(),
-        ]
-        mock_pcp = MagicMock(side_effect=outcomes)
+        # Scan pass reports NEEDS_GENERATION; then GPU attempt fails and the
+        # CPU fallback succeeds. Asserting the kwargs of BOTH generation
+        # calls ensures the fix forwards the right gpu= value — per
+        # .claude/rules/testing.md the test must lock in the contract the SUT
+        # controls (gpu=None on retry), not just that fallback was attempted.
+        def pcp(**kwargs):
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            if kwargs["gpu"] is not None:
+                raise CodecNotSupportedError(
+                    "GPU processing failed (hardware accelerator runtime error) for /data/anime.mkv"
+                )
+            return _success_result()
+
+        mock_pcp = MagicMock(side_effect=pcp)
 
         with (
             patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
@@ -157,20 +177,26 @@ class TestOrchestratorCpuFallback:
 
             counts = _run_full_scan_multi_server(_config(), selected_gpus=[("NVIDIA", "/dev/nvidia0", {})])
 
-        assert mock_pcp.call_count == 2, (
-            f"GPU CodecNotSupportedError must trigger one CPU retry (2 total calls), "
-            f"got {mock_pcp.call_count}. Pre-fix this was 1 — the fallback never ran."
+        # Two GENERATION calls: GPU attempt (raises) + CPU fallback. The
+        # check_only scan pass is separate and must not be counted as a
+        # generation attempt.
+        gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
+        assert len(gen_calls) == 2, (
+            f"GPU CodecNotSupportedError must trigger one CPU retry (2 generation calls), "
+            f"got {len(gen_calls)}. Pre-fix this was 1 — the fallback never ran."
         )
 
-        # First call: GPU attempt — must include the GPU type/device the orchestrator was given.
-        first_kwargs = mock_pcp.call_args_list[0].kwargs
-        assert first_kwargs["gpu"] == "NVIDIA", f"first call gpu kwarg should be 'NVIDIA', got {first_kwargs['gpu']!r}"
+        # First generation call: GPU attempt — must include the GPU type/device.
+        first_kwargs = gen_calls[0].kwargs
+        assert first_kwargs["gpu"] == "NVIDIA", (
+            f"first gen call gpu kwarg should be 'NVIDIA', got {first_kwargs['gpu']!r}"
+        )
         assert first_kwargs["gpu_device_path"] == "/dev/nvidia0"
 
-        # Second call: CPU fallback — must explicitly pass gpu=None / gpu_device_path=None.
-        # If the fix forwards the original gpu= here by mistake, FFmpeg would
-        # re-attempt on the same GPU and fail with the same error.
-        second_kwargs = mock_pcp.call_args_list[1].kwargs
+        # Second generation call: CPU fallback — must explicitly pass
+        # gpu=None / gpu_device_path=None. If the fix forwards the original
+        # gpu= here by mistake, FFmpeg would re-attempt on the same GPU.
+        second_kwargs = gen_calls[1].kwargs
         assert second_kwargs["gpu"] is None, (
             f"CPU fallback call must pass gpu=None to disable hardware acceleration; got {second_kwargs['gpu']!r}"
         )
@@ -178,9 +204,8 @@ class TestOrchestratorCpuFallback:
             f"CPU fallback call must pass gpu_device_path=None; got {second_kwargs['gpu_device_path']!r}"
         )
 
-        # Other kwargs should be preserved across the retry — same canonical_path,
-        # same server_id_filter, same regenerate flag. A fix that fat-fingered
-        # one of these would silently change behaviour on the retry.
+        # Other kwargs preserved across the retry — same canonical_path,
+        # same server_id_filter, same regenerate flag.
         assert second_kwargs["canonical_path"] == first_kwargs["canonical_path"]
         assert second_kwargs["server_id_filter"] == first_kwargs["server_id_filter"]
         assert second_kwargs["regenerate"] == first_kwargs["regenerate"]
@@ -216,6 +241,11 @@ class TestOrchestratorCpuFallback:
         cpu_failure = RuntimeError("CPU also failed: out of memory")
 
         def pcp_side_effect(**kwargs):
+            # Scan pass: every item needs work. Returning NEEDS_GENERATION
+            # routes it to the generation calls below (where the codec error
+            # / CPU fallback live).
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
             if kwargs["canonical_path"] == "/data/a.mkv":
                 if kwargs["gpu"] is not None:
                     raise CodecNotSupportedError("GPU processing failed for /data/a.mkv")
@@ -239,13 +269,17 @@ class TestOrchestratorCpuFallback:
             # catch the secondary failure and the dispatch should complete.
             _run_full_scan_multi_server(_config(), selected_gpus=[("NVIDIA", "/dev/nvidia0", {})])
 
-        # 3 calls total: a.mkv GPU (raises CodecError), a.mkv CPU (raises RuntimeError), b.mkv GPU (succeeds).
-        assert mock_pcp.call_count == 3, (
-            f"expected GPU-attempt + CPU-fallback for a.mkv plus GPU for b.mkv (3 calls), got {mock_pcp.call_count}"
+        # Generation calls only (ignore the check_only scan pass):
+        #   a.mkv GPU (raises CodecError) + a.mkv CPU (raises RuntimeError)
+        #   + b.mkv GPU (succeeds) = 3 generation calls.
+        gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
+        assert len(gen_calls) == 3, (
+            f"expected GPU-attempt + CPU-fallback for a.mkv plus GPU for b.mkv (3 generation calls), "
+            f"got {len(gen_calls)}"
         )
 
         # b.mkv must have been processed despite a.mkv failing on both attempts.
-        b_calls = [c for c in mock_pcp.call_args_list if c.kwargs.get("canonical_path") == "/data/b.mkv"]
-        assert len(b_calls) == 1, (
+        b_gen_calls = [c for c in gen_calls if c.kwargs.get("canonical_path") == "/data/b.mkv"]
+        assert len(b_gen_calls) == 1, (
             "/data/b.mkv must still get its turn even when /data/a.mkv exhausted both GPU and CPU attempts"
         )

--- a/tests/test_orchestrator_scan_phase.py
+++ b/tests/test_orchestrator_scan_phase.py
@@ -20,10 +20,22 @@ import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from media_preview_generator.jobs.dispatcher import reset_dispatcher
 from media_preview_generator.jobs.orchestrator import _run_full_scan_multi_server
 from media_preview_generator.processing.multi_server import MultiServerStatus
 from media_preview_generator.processing.types import ProcessableItem
 from media_preview_generator.servers.base import ServerConfig, ServerType
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_dispatcher():
+    # The scan path now feeds the singleton JobDispatcher; reset it around
+    # each test so trackers/workers from one test can't leak into the next.
+    reset_dispatcher()
+    yield
+    reset_dispatcher()
 
 
 def _config(cpu_threads: int = 1, scan_workers: int = 0):
@@ -104,7 +116,9 @@ class TestScanPhaseSkip:
 
         gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
         assert gen_calls == [], "fresh item must not trigger any generation (no permit/slot)"
-        assert counts.get("skipped_output_exists", 0) == 1
+        # Unified path counts per-file (ProcessingResult), so a scan-decided
+        # skip lands under skipped_bif_exists, not the per-publisher key.
+        assert counts.get("skipped_bif_exists", 0) == 1
 
     def test_needs_generation_item_takes_one_generation_call(self):
         items = [ProcessableItem(canonical_path="/data/new.mkv", server_id="srv-a")]
@@ -119,7 +133,7 @@ class TestScanPhaseSkip:
 
         gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
         assert len(gen_calls) == 1
-        assert counts.get("published", 0) == 1
+        assert counts.get("generated", 0) == 1
 
     def test_skipped_item_attributed_to_library_scan_worker(self):
         """Files-panel attribution: a scan-decided skip is labelled 'Library scan'."""
@@ -152,9 +166,9 @@ class TestScanPhaseAccountingParity:
         mock_pcp = MagicMock(side_effect=pcp)
         counts = _run(_config(cpu_threads=2), mock_pcp, items)
 
-        # 3 skipped + 2 published, every item accounted for.
-        assert counts.get("skipped_output_exists", 0) == 3
-        assert counts.get("published", 0) == 2
+        # 3 skipped + 2 generated, every item accounted for (per-file counts).
+        assert counts.get("skipped_bif_exists", 0) == 3
+        assert counts.get("generated", 0) == 2
 
 
 class TestGenerationCapHoldsUnderHighScanConcurrency:
@@ -195,4 +209,4 @@ class TestGenerationCapHoldsUnderHighScanConcurrency:
             f"generation concurrency exceeded the cap: max_active={max_active} > cap={cap}. "
             "The scan phase must not let more than `generators` FFmpeg calls run at once."
         )
-        assert counts.get("published", 0) == n_items
+        assert counts.get("generated", 0) == n_items

--- a/tests/test_orchestrator_scan_phase.py
+++ b/tests/test_orchestrator_scan_phase.py
@@ -1,0 +1,198 @@
+"""Scan-phase decoupling on the full-scan dispatcher (issue #243).
+
+The orchestrator runs a cheap ``check_only=True`` pass on every item BEFORE
+acquiring a generation permit. Items that are already fresh (or otherwise
+terminal) are recorded without ever taking a generator slot; only items that
+report NEEDS_GENERATION go on to a (capped) generation call. These tests lock
+in:
+
+* a terminal scan result takes NO generation call (no permit/slot),
+* a NEEDS_GENERATION item takes exactly one generation call,
+* the generation cap holds even when the scan sweeps at higher concurrency,
+* per-item accounting still matches the item count,
+* skipped items are attributed to the "Library scan" worker label.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from media_preview_generator.jobs.orchestrator import _run_full_scan_multi_server
+from media_preview_generator.processing.multi_server import MultiServerStatus
+from media_preview_generator.processing.types import ProcessableItem
+from media_preview_generator.servers.base import ServerConfig, ServerType
+
+
+def _config(cpu_threads: int = 1, scan_workers: int = 0):
+    return SimpleNamespace(
+        gpu_threads=0,
+        cpu_threads=cpu_threads,
+        scan_workers=scan_workers,
+        working_tmp_folder="/tmp/work",
+        plex_url="",
+        plex_token="",
+        webhook_paths=None,
+        server_id_filter=None,
+    )
+
+
+def _server_config(server_id, server_type=ServerType.JELLYFIN):
+    return ServerConfig(
+        id=server_id,
+        type=server_type,
+        name=f"Test {server_type.value}",
+        enabled=True,
+        url="http://test",
+        auth={"access_token": "t"},
+    )
+
+
+def _registry_with_items(items):
+    cfg = _server_config("srv-a", ServerType.JELLYFIN)
+    registry_mock = MagicMock()
+    registry_mock.configs.return_value = [cfg]
+    proc = MagicMock()
+    proc.list_canonical_paths.return_value = iter(items)
+    return registry_mock, proc
+
+
+def _skip_result(path):
+    return MagicMock(
+        status=MultiServerStatus.SKIPPED,
+        publishers=[MagicMock(status=MagicMock(value="skipped_output_exists"))],
+        canonical_path=path,
+        message="All outputs fresh; FFmpeg skipped",
+    )
+
+
+def _published_result(path):
+    return MagicMock(
+        status=MultiServerStatus.PUBLISHED,
+        publishers=[MagicMock(status=MagicMock(value="published"))],
+        canonical_path=path,
+        message="",
+    )
+
+
+def _run(config, mock_pcp, items, selected_gpus=None):
+    registry_mock, proc = _registry_with_items(items)
+    with (
+        patch("media_preview_generator.web.settings_manager.get_settings_manager") as mock_sm,
+        patch("media_preview_generator.servers.ServerRegistry") as mock_registry,
+        patch("media_preview_generator.processing.get_processor_for", return_value=proc),
+        patch("media_preview_generator.processing.multi_server.process_canonical_path", mock_pcp),
+    ):
+        mock_sm.return_value.get.return_value = [{"id": "srv-a", "type": "jellyfin", "enabled": True}]
+        mock_registry.from_settings.return_value = registry_mock
+        return _run_full_scan_multi_server(config, selected_gpus=selected_gpus or [])
+
+
+class TestScanPhaseSkip:
+    def test_fresh_item_takes_no_generation_call(self):
+        """An already-fresh item is decided by the scan pass alone."""
+        items = [ProcessableItem(canonical_path="/data/fresh.mkv", server_id="srv-a")]
+
+        def pcp(**kwargs):
+            assert kwargs.get("check_only") is True, "a fresh item must never reach a generation call"
+            return _skip_result(kwargs["canonical_path"])
+
+        mock_pcp = MagicMock(side_effect=pcp)
+        counts = _run(_config(cpu_threads=2), mock_pcp, items)
+
+        gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
+        assert gen_calls == [], "fresh item must not trigger any generation (no permit/slot)"
+        assert counts.get("skipped_output_exists", 0) == 1
+
+    def test_needs_generation_item_takes_one_generation_call(self):
+        items = [ProcessableItem(canonical_path="/data/new.mkv", server_id="srv-a")]
+
+        def pcp(**kwargs):
+            if kwargs.get("check_only"):
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            return _published_result(kwargs["canonical_path"])
+
+        mock_pcp = MagicMock(side_effect=pcp)
+        counts = _run(_config(cpu_threads=2), mock_pcp, items)
+
+        gen_calls = [c for c in mock_pcp.call_args_list if not c.kwargs.get("check_only")]
+        assert len(gen_calls) == 1
+        assert counts.get("published", 0) == 1
+
+    def test_skipped_item_attributed_to_library_scan_worker(self):
+        """Files-panel attribution: a scan-decided skip is labelled 'Library scan'."""
+        items = [ProcessableItem(canonical_path="/data/fresh.mkv", server_id="srv-a")]
+        mock_pcp = MagicMock(side_effect=lambda **kw: _skip_result(kw["canonical_path"]))
+
+        with patch("media_preview_generator.processing.generator._notify_file_result") as mock_notify:
+            _run(_config(cpu_threads=2), mock_pcp, items)
+
+        # worker_label is the 4th positional arg to _notify_file_result.
+        assert mock_notify.called
+        worker_label = mock_notify.call_args.args[3]
+        assert worker_label == "Library scan", f"skip should be attributed to 'Library scan', got {worker_label!r}"
+
+
+class TestScanPhaseAccountingParity:
+    def test_mixed_skip_and_generate_counts_every_item(self):
+        items = [ProcessableItem(canonical_path=f"/data/skip-{i}.mkv", server_id="srv-a") for i in range(3)] + [
+            ProcessableItem(canonical_path=f"/data/gen-{i}.mkv", server_id="srv-a") for i in range(2)
+        ]
+
+        def pcp(**kwargs):
+            path = kwargs["canonical_path"]
+            if kwargs.get("check_only"):
+                if "skip-" in path:
+                    return _skip_result(path)
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            return _published_result(path)
+
+        mock_pcp = MagicMock(side_effect=pcp)
+        counts = _run(_config(cpu_threads=2), mock_pcp, items)
+
+        # 3 skipped + 2 published, every item accounted for.
+        assert counts.get("skipped_output_exists", 0) == 3
+        assert counts.get("published", 0) == 2
+
+
+class TestGenerationCapHoldsUnderHighScanConcurrency:
+    def test_concurrent_generations_never_exceed_cap(self):
+        """The core #243 safety property: even when many items sweep through
+        the scan at high concurrency, the number of *simultaneous* generation
+        calls never exceeds the generator count (cpu_threads here).
+        """
+        cap = 2
+        n_items = 24
+        items = [ProcessableItem(canonical_path=f"/data/x-{i}.mkv", server_id="srv-a") for i in range(n_items)]
+
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def pcp(**kwargs):
+            nonlocal active, max_active
+            if kwargs.get("check_only"):
+                # Every item needs generation → forces them all to contend
+                # for the capped permits.
+                return MagicMock(status=MultiServerStatus.NEEDS_GENERATION, publishers=[])
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            try:
+                time.sleep(0.02)  # hold the permit long enough to overlap
+            finally:
+                with lock:
+                    active -= 1
+            return _published_result(kwargs["canonical_path"])
+
+        mock_pcp = MagicMock(side_effect=pcp)
+        # scan_workers high so the sweep itself is wide; generation cap = cpu_threads.
+        counts = _run(_config(cpu_threads=cap, scan_workers=32), mock_pcp, items)
+
+        assert max_active <= cap, (
+            f"generation concurrency exceeded the cap: max_active={max_active} > cap={cap}. "
+            "The scan phase must not let more than `generators` FFmpeg calls run at once."
+        )
+        assert counts.get("published", 0) == n_items

--- a/tests/test_priority.py
+++ b/tests/test_priority.py
@@ -204,84 +204,64 @@ class TestDispatcherPriority:
         dispatcher._ensure_dispatch_running = lambda: None
         return dispatcher
 
+    def _add_tracker(self, dispatcher, job_id, items, priority):
+        """Register a tracker directly (no submit_items → no background
+        checking threads), so the priority picker can be exercised
+        synchronously and deterministically.
+        """
+        tracker = JobTracker(
+            job_id=job_id,
+            items=items,
+            config=_make_config(),
+            registry=MagicMock(),
+            priority=priority,
+        )
+        with dispatcher._trackers_lock:
+            dispatcher._trackers[job_id] = tracker
+        return tracker
+
     def test_high_priority_dispatched_first(self):
-        """Items from a high-priority job should be returned before normal."""
+        """Items from a high-priority job should be checked before normal.
+
+        The priority-aware entry picker is ``_get_next_check_item`` now
+        (items enter the checking queue first); it shares the same
+        (priority, submission_order) sort the processing picker uses.
+        """
         dispatcher = self._make_dispatcher()
-        config = _make_config()
+        self._add_tracker(dispatcher, "low-job", [("k1", "Low Item", "movie")], PRIORITY_LOW)
+        self._add_tracker(dispatcher, "high-job", [("k2", "High Item", "movie")], PRIORITY_HIGH)
 
-        dispatcher.submit_items(
-            job_id="low-job",
-            items=[("k1", "Low Item", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_LOW,
-        )
-        dispatcher.submit_items(
-            job_id="high-job",
-            items=[("k2", "High Item", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_HIGH,
-        )
+        picked = dispatcher._get_next_check_item()
+        assert picked is not None
+        assert picked[0].job_id == "high-job"
 
-        item = dispatcher._get_next_item()
-        assert item is not None
-        assert item[0] == "high-job"
-
-        item2 = dispatcher._get_next_item()
-        assert item2 is not None
-        assert item2[0] == "low-job"
+        picked2 = dispatcher._get_next_check_item()
+        assert picked2 is not None
+        assert picked2[0].job_id == "low-job"
 
     def test_same_priority_fifo(self):
         """Within the same priority, earlier submissions should come first."""
         dispatcher = self._make_dispatcher()
-        config = _make_config()
+        self._add_tracker(dispatcher, "first", [("k1", "First", "movie")], PRIORITY_NORMAL)
+        self._add_tracker(dispatcher, "second", [("k2", "Second", "movie")], PRIORITY_NORMAL)
 
-        dispatcher.submit_items(
-            job_id="first",
-            items=[("k1", "First", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_NORMAL,
-        )
-        dispatcher.submit_items(
-            job_id="second",
-            items=[("k2", "Second", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_NORMAL,
-        )
-
-        item = dispatcher._get_next_item()
-        assert item is not None
-        assert item[0] == "first"
+        picked = dispatcher._get_next_check_item()
+        assert picked is not None
+        assert picked[0].job_id == "first"
 
     def test_update_job_priority_reorders(self):
         """Changing a job's priority should affect subsequent dispatch order."""
         dispatcher = self._make_dispatcher()
-        config = _make_config()
-
-        dispatcher.submit_items(
-            job_id="job-a",
-            items=[("k1", "A1", "movie"), ("k2", "A2", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_NORMAL,
-        )
-        dispatcher.submit_items(
-            job_id="job-b",
-            items=[("k3", "B1", "movie")],
-            config=config,
-            registry=MagicMock(),
-            priority=PRIORITY_NORMAL,
-        )
+        self._add_tracker(dispatcher, "job-a", [("k1", "A1", "movie"), ("k2", "A2", "movie")], PRIORITY_NORMAL)
+        self._add_tracker(dispatcher, "job-b", [("k3", "B1", "movie")], PRIORITY_NORMAL)
 
         dispatcher.update_job_priority("job-b", PRIORITY_HIGH)
 
-        item = dispatcher._get_next_item()
-        assert item is not None
-        assert item[0] == "job-b"
+        picked = dispatcher._get_next_check_item()
+        assert picked is not None
+        assert picked[0].job_id == "job-b"
 
     def test_empty_queue_returns_none(self):
         dispatcher = self._make_dispatcher()
+        assert dispatcher._get_next_check_item() is None
         assert dispatcher._get_next_item() is None

--- a/tests/test_processing_check_only.py
+++ b/tests/test_processing_check_only.py
@@ -290,3 +290,36 @@ class TestPhaseLabelByMode:
             )
         assert "Preparing to generate…" in phases
         assert "Checking existing previews…" not in phases
+
+
+class TestCancellationDuringGeneration:
+    """A cancelled FFmpeg run (job cancelled / container restart mid-extract)
+    raises CancellationError. It must propagate as cancellation — NOT be
+    swallowed into a FAILED result with a misleading "corrupt video file"
+    traceback (the worker's CancellationError handler records it cleanly).
+    Regression: a cancelled scan logged a scary diagnostic traceback +
+    "Common causes: corrupt video file…" advice.
+    """
+
+    def test_cancellation_reraises_not_swallowed_as_failed(self, mock_config_for_processing, tmp_path):
+        from media_preview_generator.processing.generator import CancellationError
+
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=False,
+            ),
+            patch(
+                "media_preview_generator.processing.multi_server.generate_images",
+                side_effect=CancellationError("cancelled"),
+            ),
+            pytest.raises(CancellationError),
+        ):
+            process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=False,
+            )

--- a/tests/test_processing_check_only.py
+++ b/tests/test_processing_check_only.py
@@ -230,3 +230,63 @@ class TestCheckOnlyDoesNotChangeNormalPath:
             )
         mock_gen.assert_called()
         assert result.status is not MultiServerStatus.NEEDS_GENERATION
+
+
+class TestPhaseLabelByMode:
+    """The pre-FFmpeg freshness probe is shared by the checking stage and the
+    generation worker, but its phase label must differ. "Checking existing
+    previews…" is the checking stage's identity (check_only=True, own threads);
+    a generation worker running the same probe must read as preparing to
+    generate, not "checking" — otherwise the worker card shows the old
+    "GPU worker stuck checking" symptom (regression: webhook job 68a110ee).
+    """
+
+    def test_check_only_pass_is_labelled_checking(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        phases: list[str] = []
+        with patch(
+            "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+            return_value=False,
+        ):
+            process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=True,
+                phase_callback=phases.append,
+            )
+        assert "Checking existing previews…" in phases
+        assert "Preparing to generate…" not in phases
+
+    def test_generation_pass_is_not_labelled_checking(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        phases: list[str] = []
+
+        def fake_generate_images(video_file, output_folder, *args, **kwargs):
+            from pathlib import Path as _P
+
+            _P(output_folder).mkdir(parents=True, exist_ok=True)
+            (_P(output_folder) / "00000.jpg").write_bytes(b"\xff\xd8\xff" + b"\x00" * 64)
+            return (True, 1, "h264", 1.0, 30.0, None)
+
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=False,
+            ),
+            patch(
+                "media_preview_generator.processing.multi_server.generate_images",
+                side_effect=fake_generate_images,
+            ),
+        ):
+            process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=False,
+                phase_callback=phases.append,
+            )
+        assert "Preparing to generate…" in phases
+        assert "Checking existing previews…" not in phases

--- a/tests/test_processing_check_only.py
+++ b/tests/test_processing_check_only.py
@@ -1,0 +1,232 @@
+"""Tests for ``process_canonical_path(check_only=True)``.
+
+``check_only`` runs every pre-FFmpeg step a normal call would (publisher
+resolution, source-missing probe, the all-fresh short-circuit and its side
+effects, the regenerate meta-clear) and then stops at the FFmpeg boundary,
+returning :attr:`MultiServerStatus.NEEDS_GENERATION` instead of extracting
+frames. Terminal outcomes (SKIPPED, PUBLISHED pending-registration, NO_OWNERS,
+SKIPPED_FILE_NOT_FOUND) return exactly as they do without the flag.
+
+The orchestrator's high-concurrency scan phase relies on this so the heavy
+FFmpeg path can only run once a (capped) generation permit is held — see
+``jobs/orchestrator.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from media_preview_generator.processing.frame_cache import reset_frame_cache
+from media_preview_generator.processing.multi_server import (
+    MultiServerStatus,
+    process_canonical_path,
+)
+from media_preview_generator.servers import (
+    ServerRegistry,
+    ServerType,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_frame_cache_singleton():
+    reset_frame_cache()
+    yield
+    reset_frame_cache()
+
+
+@pytest.fixture
+def mock_config_for_processing(mock_config, tmp_path):
+    mock_config.working_tmp_folder = str(tmp_path / "tmp")
+    mock_config.tmp_folder = str(tmp_path / "tmp")
+    return mock_config
+
+
+def _emby_registry(tmp_path) -> ServerRegistry:
+    """A single Emby server owning ``tmp_path/movies``.
+
+    Emby uses the filename-derived sidecar adapter (no item-id lookup, no
+    network), which keeps these tests deterministic and offline.
+    """
+    return ServerRegistry.from_settings(
+        [
+            {
+                "id": "emby-1",
+                "type": ServerType.EMBY.value,
+                "name": "emby-1",
+                "enabled": True,
+                "url": "http://x",
+                "auth": {"token": "t", "method": "api_key", "api_key": "k"},
+                "libraries": [
+                    {
+                        "id": "1",
+                        "name": "Movies",
+                        "remote_paths": [str(tmp_path / "movies")],
+                        "enabled": True,
+                    }
+                ],
+                "exclude_paths": [],
+                "output": {
+                    "adapter": "emby_sidecar",
+                    "plex_config_folder": "/cfg",
+                    "width": 320,
+                    "frame_interval": 10,
+                },
+            }
+        ]
+    )
+
+
+def _seed_media(tmp_path, name: str = "Foo (2024).mkv"):
+    media_dir = tmp_path / "movies"
+    media_dir.mkdir(parents=True, exist_ok=True)
+    media_file = media_dir / name
+    media_file.write_bytes(b"placeholder")
+    return media_file
+
+
+class TestCheckOnlyTerminalOutcomes:
+    """Terminal (non-generation) outcomes return as-is under check_only."""
+
+    def test_no_owners_returns_terminal_not_needs_generation(self, mock_config_for_processing):
+        result = process_canonical_path(
+            canonical_path="/nope/Foo.mkv",
+            registry=ServerRegistry(),
+            config=mock_config_for_processing,
+            check_only=True,
+        )
+        assert result.status is MultiServerStatus.NO_OWNERS
+
+    def test_source_missing_returns_file_not_found(self, mock_config_for_processing, tmp_path):
+        # Registry owns the folder, but no file exists on disk there.
+        registry = _emby_registry(tmp_path)
+        missing = str(tmp_path / "movies" / "Ghost (2024).mkv")
+        result = process_canonical_path(
+            canonical_path=missing,
+            registry=registry,
+            config=mock_config_for_processing,
+            check_only=True,
+        )
+        assert result.status is MultiServerStatus.SKIPPED_FILE_NOT_FOUND
+
+    def test_all_fresh_returns_skipped_without_ffmpeg(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=True,
+            ),
+            patch("media_preview_generator.processing.multi_server.generate_images") as mock_gen,
+        ):
+            result = process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=True,
+            )
+        assert result.status is MultiServerStatus.SKIPPED
+        mock_gen.assert_not_called()
+
+    def test_pending_registration_returns_published_not_needs_generation(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        # Force the "outputs fresh but server still needs item registration"
+        # branch: all paths fresh, and the server is classified as needing
+        # registration with an unresolved id. That yields a PUBLISHED
+        # (pending) aggregate — terminal, NOT NEEDS_GENERATION.
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=True,
+            ),
+            patch(
+                "media_preview_generator.processing.multi_server._server_needs_item_registration",
+                return_value=True,
+            ),
+            patch("media_preview_generator.processing.multi_server.generate_images") as mock_gen,
+        ):
+            result = process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=True,
+            )
+        assert result.status is MultiServerStatus.PUBLISHED
+        mock_gen.assert_not_called()
+
+
+class TestCheckOnlyNeedsGeneration:
+    """Items that genuinely need FFmpeg report NEEDS_GENERATION and run none."""
+
+    def test_stale_output_returns_needs_generation_without_ffmpeg(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=False,
+            ),
+            patch("media_preview_generator.processing.multi_server.generate_images") as mock_gen,
+        ):
+            result = process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                check_only=True,
+            )
+        assert result.status is MultiServerStatus.NEEDS_GENERATION
+        mock_gen.assert_not_called()
+
+    def test_regenerate_returns_needs_generation_without_ffmpeg(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+        with patch("media_preview_generator.processing.multi_server.generate_images") as mock_gen:
+            result = process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                regenerate=True,
+                check_only=True,
+            )
+        assert result.status is MultiServerStatus.NEEDS_GENERATION
+        mock_gen.assert_not_called()
+
+
+class TestCheckOnlyDoesNotChangeNormalPath:
+    """Sanity: default check_only=False still extracts frames for stale items.
+
+    Guards against the boundary insertion accidentally short-circuiting the
+    real generation path.
+    """
+
+    def test_normal_call_still_generates_when_stale(self, mock_config_for_processing, tmp_path):
+        registry = _emby_registry(tmp_path)
+        media_file = _seed_media(tmp_path)
+
+        def fake_generate_images(video_file, output_folder, *args, **kwargs):
+            from pathlib import Path as _P
+
+            _P(output_folder).mkdir(parents=True, exist_ok=True)
+            (_P(output_folder) / "00000.jpg").write_bytes(b"\xff\xd8\xff" + b"\x00" * 64)
+            return (True, 1, "h264", 1.0, 30.0, None)
+
+        with (
+            patch(
+                "media_preview_generator.processing.multi_server.outputs_fresh_for_source",
+                return_value=False,
+            ),
+            patch(
+                "media_preview_generator.processing.multi_server.generate_images",
+                side_effect=fake_generate_images,
+            ) as mock_gen,
+        ):
+            result = process_canonical_path(
+                canonical_path=str(media_file),
+                registry=registry,
+                config=mock_config_for_processing,
+                # check_only defaults to False
+            )
+        mock_gen.assert_called()
+        assert result.status is not MultiServerStatus.NEEDS_GENERATION


### PR DESCRIPTION
Implements #243 — separates the lightweight "does a preview already exist?" check from the heavy FFmpeg generation.

**The problem:** scanning a large library tied up your GPU/CPU workers just *checking* which files were already done, instead of generating previews.

**The fix:** checking now runs on its own lightweight workers, so the GPU/CPU workers are reserved for actual generation. One shared engine handles this for every trigger (webhooks, manual scans, recently-added) and every server (Plex/Emby/Jellyfin).

**New setting:** *Files checked at once* (Settings) tunes how many files are checked in parallel — `0 = Auto`. It does not change how many previews generate at once.

**Status:** 3,194 unit tests pass. Still needs real-world testing on a multi-server (Plex/Emby/Jellyfin) setup — a Docker image is built for this PR (`ghcr.io/stevezau/media_preview_generator:pr-255`) to make that easy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
