### PR TITLE
docs(unraid): surface --runtime=nvidia requirement in CA template (#260)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -401,6 +401,14 @@ docker run -d \
   stevezzau/media_preview_generator:latest
 ```
 
+> [!WARNING]
+> On Unraid, use `--runtime=nvidia` — **not** `--gpus all`. If you see
+> `docker: Error response from daemon: AMD CDI spec not found`, that's
+> Docker trying to resolve `--gpus all` through the Container Device
+> Interface (CDI). Unraid doesn't ship CDI specs, so the daemon falls
+> through to whatever spec it finds. Switching to `--runtime=nvidia`
+> bypasses CDI and uses the Nvidia-Driver plugin directly.
+
 ### Important Unraid Notes
 
 **PUID/PGID Values** — Unraid uses `nobody:users` by default:

--- a/unraid-templates/media-preview-generator.xml
+++ b/unraid-templates/media-preview-generator.xml
@@ -32,13 +32,23 @@ If your Plex container uses a custom network (like br1 or macvlan), this contain
 must use the SAME network to communicate with Plex. Change the Network Type setting
 to match your Plex container's network.
 
-For Intel QuickSync, /dev/dri is passed through automatically (see GPU Device below).
+GPU SETUP — pick ONE path:
 
-For NVIDIA GPU support, you must:
-1. Install NVIDIA driver and nvidia-container-toolkit on Unraid
-2. Add --runtime=nvidia to Extra Parameters
-3. Or use the Nvidia-Driver and nvidia-container-toolkit plugins from Community Applications
-4. Add NVIDIA_DRIVER_CAPABILITIES=all to the environment variables below (the 'graphics' capability is required for Dolby Vision Profile 5 thumbnails; 'compute,video,utility' alone only covers NVDEC and nvidia-smi).
+[Intel / AMD]
+  Pass /dev/dri through (already configured below — no further action needed).
+
+[NVIDIA] — REQUIRED STEPS, in this order:
+  1. Install the Nvidia-Driver plugin from Community Applications (bundles the NVIDIA driver and nvidia-container-toolkit needed for --runtime=nvidia).
+  2. Add  --runtime=nvidia  to "Extra Parameters" on this template (NOT --gpus all).
+  3. Set the NVIDIA_VISIBLE_DEVICES and NVIDIA_DRIVER_CAPABILITIES variables below.
+  4. Optional: if your host has no Intel iGPU and the container fails with a /dev/dri error, remove the Intel GPU Device field.
+
+  Common error: "docker: Error response from daemon: AMD CDI spec not found"
+    -> You're using --gpus all on Unraid. Replace it with --runtime=nvidia.
+
+  Why NVIDIA_DRIVER_CAPABILITIES=all? The 'graphics' capability is required for
+  Dolby Vision Profile 5 thumbnails (libplacebo Vulkan tone-mapping).
+  'compute,video,utility' alone covers only CUDA/NVDEC and nvidia-smi.
     </Overview>
     <Category>MediaApp:Video MediaServer:Video</Category>
     <WebUI>http://[IP]:[PORT:8080]/</WebUI>
@@ -50,6 +60,7 @@ For NVIDIA GPU support, you must:
     <DateInstalled/>
     <Date>2025-01-01</Date>
     <Changes>
+[2026-06-01] Surfaced the NVIDIA --runtime=nvidia requirement in field labels and the Overview to prevent "AMD CDI spec not found" errors when users set NVIDIA env vars without adding the runtime flag to Extra Parameters (issue #260)
 [2026-05-27] Renamed to media-preview-generator; image moved to stevezzau/media_preview_generator (old plex_generate_vid_previews image is deprecated)
 [2025-01-01] Initial release with web UI and OAuth support
     </Changes>
@@ -91,8 +102,8 @@ For NVIDIA GPU support, you must:
     <Config Name="Intel GPU Device" Target="/dev/dri" Default="/dev/dri" Mode="" Description="Pass through Intel GPU for QuickSync acceleration" Type="Device" Display="advanced" Required="false" Mask="false">/dev/dri</Config>
 
     <!-- GPU Support (NVIDIA) -->
-    <Config Name="NVIDIA Driver Capabilities" Target="NVIDIA_DRIVER_CAPABILITIES" Default="all" Mode="" Description="NVIDIA driver capabilities to inject into the container. Use 'all' (recommended) so the 'graphics' capability is included — this is required for Dolby Vision Profile 5 thumbnails (libplacebo Vulkan tone-mapping). 'compute,video,utility' alone only covers CUDA/NVDEC and will NOT give you DV5 support. Only applied if you also set --runtime=nvidia in Extra Parameters." Type="Variable" Display="advanced" Required="false" Mask="false">all</Config>
-    <Config Name="NVIDIA Visible Devices" Target="NVIDIA_VISIBLE_DEVICES" Default="" Mode="" Description="Which NVIDIA GPUs to expose (e.g. 'all', or a specific UUID). Only applied if you also set --runtime=nvidia in Extra Parameters." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+    <Config Name="NVIDIA Driver Capabilities (requires --runtime=nvidia in Extra Parameters)" Target="NVIDIA_DRIVER_CAPABILITIES" Default="all" Mode="" Description="REQUIRES --runtime=nvidia in Extra Parameters — without it, this variable is ignored and the container will either fail to start (e.g. 'AMD CDI spec not found') or fall back to CPU. Recommended value: 'all' (includes the 'graphics' capability needed for Dolby Vision Profile 5 thumbnails via libplacebo Vulkan tone-mapping). 'compute,video,utility' alone covers only CUDA/NVDEC and will NOT give you DV5 support." Type="Variable" Display="advanced" Required="false" Mask="false">all</Config>
+    <Config Name="NVIDIA Visible Devices (requires --runtime=nvidia in Extra Parameters)" Target="NVIDIA_VISIBLE_DEVICES" Default="" Mode="" Description="REQUIRES --runtime=nvidia in Extra Parameters — without it, this variable is ignored. Which NVIDIA GPUs to expose to the container, e.g. 'all' or a specific GPU UUID. Do NOT use --gpus all on Unraid; that triggers CDI resolution and fails with 'AMD CDI spec not found'." Type="Variable" Display="advanced" Required="false" Mask="false"/>
 
     <!-- Advanced -->
     <Config Name="Log Level" Target="LOG_LEVEL" Default="INFO" Mode="" Description="Logging level: DEBUG, INFO, WARNING, ERROR" Type="Variable" Display="advanced" Required="false" Mask="false">INFO</Config>


### PR DESCRIPTION
## Summary

Fix for [#260](https://github.com/stevezau/media_preview_generator/issues/260) — Unraid NVIDIA users hitting `docker: Error response from daemon: AMD CDI spec not found` when migrating from Intel iGPU to NVIDIA.

The Unraid CA template already documented the `--runtime=nvidia` requirement, but only in (a) Overview prose and (b) the *tail* of two field descriptions. Users filling in `NVIDIA_VISIBLE_DEVICES` / `NVIDIA_DRIVER_CAPABILITIES` never read that far and ended up with `--gpus all` from prior config — which triggers Docker's CDI resolution on Unraid hosts that don't ship CDI specs, producing the reported error.

This is a docs-and-template-only change. No Python touched, no behavior change.

## Changes

**`unraid-templates/media-preview-generator.xml`**
- Lift `--runtime=nvidia` requirement into the `<Config Name="…">` labels (Unraid renders Name as the field label; Description is only a tooltip).
- Lead each NVIDIA field description with `REQUIRES --runtime=nvidia` and name the exact error string `AMD CDI spec not found` so search engines land on our docs.
- Restructure the Overview to split GPU setup by vendor (`[Intel / AMD]` vs `[NVIDIA]`) with required steps numbered for the NVIDIA path.
- Note that the CA Nvidia-Driver plugin bundles the nvidia-container-toolkit.
- Add a `<Changes>` entry.

**`docs/getting-started.md`**
- Add a `> [!WARNING]` callout under the Unraid NVIDIA `docker run` example explaining the CDI failure mode and pointing to `--runtime=nvidia`.

## What this does NOT change

- `DOCKERHUB_README.md` and the generic Linux Docker example in `docs/getting-started.md` still recommend `--gpus all` — correct for stock Linux with NVIDIA Container Toolkit; CDI failure mode is Unraid-specific.
- `docker-compose.example.yml` already had `runtime: nvidia` as the NVIDIA option (commented).
- No container-side detection added — the CDI error happens at `docker run` time before the entrypoint can log anything.

## Test plan

- [x] `python3 -m xml.etree.ElementTree` parses the modified template cleanly.
- [x] Architecture Review agent run against the diff — no HIGH/MED findings; two LOW findings (missing toolkit mention + over-prescriptive Intel-field removal step) applied as inline fixes before commit.
- [ ] Unraid CA installs the new template without form-rendering issues (the new `<Config Name="…">` labels add `(requires --runtime=nvidia in Extra Parameters)` — parentheses already have precedent in the existing `Frame Interval (seconds)` field, equals/dashes are standard XML attribute characters).
- [ ] Verify the rendered field labels look reasonable in the Unraid Docker template editor (not truncated visually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)