### PR TITLE
fix(ci): stop plugin release tags from triggering the app image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,14 @@ name: CI
 on:
   push:
     branches: [dev]
-    tags: ['*.*.*']
+    # App release tags are pure semver (e.g. 4.2.1). Exclude plugin tags
+    # (plugin-v10.11.0.3) — they own jellyfin-plugin.yml and must NOT trigger
+    # the app image build: the tag name is fed to SETUPTOOLS_SCM_PRETEND_VERSION,
+    # and a non-PEP440 value ("plugin-v…") aborts the wheel build (and would
+    # otherwise push :latest from a plugin release).
+    tags:
+      - '*.*.*'
+      - '!plugin-*'
     paths-ignore:
       - 'docs/**'
       - '*.md'


### PR DESCRIPTION
## Problem
The `plugin-v10.11.0.3` release tag triggered a **failed app image build** ([run 28348976241](https://github.com/stevezau/media_preview_generator/actions/runs/28348976241/job/83977892686)).

`ci.yml`'s push trigger was `tags: ['*.*.*']`, which matches plugin release tags as well as app semver tags. When a `plugin-v*` tag pushed, the app Docker build ran and fed the tag name into `SETUPTOOLS_SCM_PRETEND_VERSION=plugin-v10.11.0.3`. That's not a PEP 440 version, so setuptools_scm aborts the wheel build:

```
File ".../setuptools_scm/_integration/setuptools.py", line 203, in infer_version
ERROR: failed to build wheel (exit code 1)
```

Worse, had it *succeeded*, the tag-push path pushes `:<tag>` **and `:latest`** — so a plugin release would have clobbered the app's `:latest` image.

> Note: the **dev branch build was fine** (`b24c5a7` → run 28347871753 ✅). Only the plugin-tag-triggered app build failed.

## Fix
Plugin tags are owned by `jellyfin-plugin.yml` (`plugin-v*.*.*.*`) — they must not trigger `ci.yml`. Exclude them with a `!plugin-*` negation, keeping the semver `*.*.*` positive:

```yaml
    tags:
      - '*.*.*'
      - '!plugin-*'
```

`4.2.1` still triggers; `plugin-v10.11.0.3` no longer does. Branch (`dev`) pushes are unaffected.

## Verification
Architecture Review confirmed the negation semantics (order-correct: negative after positive excludes), that `paths-ignore` is irrelevant to tag refs, and that nothing else in `ci.yml` depends on the old single-pattern form. The broad `!plugin-*` is intentionally a superset of the plugin workflow's `plugin-v*.*.*.*` (fail-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
