### PR TITLE
fix(jellyfin): generate previews for every version of multi-version items

### DIFF
--- a/media_preview_generator/processing/_embyish.py
+++ b/media_preview_generator/processing/_embyish.py
@@ -47,7 +47,7 @@ class _EmbyishProcessor(_MediaServerProcessor):
         params: dict[str, Any] = {
             "IncludeItemTypes": "Movie,Episode",
             "Recursive": "true",
-            "Fields": "Path,DateCreated",
+            "Fields": "Path,DateCreated,MediaSourceCount",
             "SortBy": "DateCreated",
             "SortOrder": "Descending",
             "Limit": 500,
@@ -66,17 +66,21 @@ class _EmbyishProcessor(_MediaServerProcessor):
             created_str = str(raw.get("DateCreated") or "")
             if not created_str or not _within_lookback(created_str, cutoff):
                 continue
-            path = str(raw.get("Path") or "")
-            if not path:
-                continue
-            for canonical in self._canonical_paths_for(path, server_config):
-                yield ProcessableItem(
-                    canonical_path=canonical,
-                    server_id=server_config.id,
-                    item_id_by_server={server_config.id: str(raw.get("Id") or "")},
-                    title=_format_title(raw),
-                    library_id=str(raw.get("ParentId") or "") or None,
-                )
+            # #268 (Emby/Jellyfin): emit one ProcessableItem per *version*
+            # so a recently-added multi-version item previews every version,
+            # keyed by each version's own MediaSource id (off-media trickplay
+            # is per-GUID). Single-version items pay no extra round-trip.
+            title = _format_title(raw)
+            library_id = str(raw.get("ParentId") or "") or None
+            for version_id, version_path in client.media_item_versions(raw):
+                for canonical in self._canonical_paths_for(version_path, server_config):
+                    yield ProcessableItem(
+                        canonical_path=canonical,
+                        server_id=server_config.id,
+                        item_id_by_server={server_config.id: version_id},
+                        title=title,
+                        library_id=library_id,
+                    )
 
 
 def _within_lookback(created_iso: str, cutoff: datetime) -> bool:

--- a/media_preview_generator/servers/_embyish.py
+++ b/media_preview_generator/servers/_embyish.py
@@ -490,6 +490,77 @@ class EmbyApiClient(MediaServer):
             )
         return libraries
 
+    def _fetch_media_sources(self, item_id: str) -> list[tuple[str, str]]:
+        """Return ``[(source_id, source_path)]`` for every MediaSource of an item.
+
+        Alternate-version (merged) items collapse to a single ``/Items`` row
+        whose top-level ``Path`` is only the *primary* version; the other
+        versions live in ``MediaSources``. A targeted ``Fields=MediaSources``
+        fetch surfaces them all inline (verified on Jellyfin 10.11 and Emby).
+
+        Each MediaSource's ``Id`` is the per-version item GUID Jellyfin keys
+        trickplay on — its player resolves trickplay via
+        ``GetItemById(mediaSourceId ?? itemId)`` since 10.11.5 (PR #15757) —
+        so surfacing the source id lets off-media trickplay land in the right
+        per-version directory. Returns ``[]`` on any failure; the caller then
+        falls back to the primary path so behaviour matches the pre-fix scan.
+        """
+        params: dict[str, Any] = {"Ids": item_id, "Fields": "Path,MediaSources"}
+        user_id = self._user_id()
+        if user_id:
+            params["UserId"] = user_id
+        try:
+            data = self._request("GET", "/Items", params=params).json()
+        except Exception as exc:  # noqa: BLE001 — degrade to primary-only on any error
+            logger.debug("{} MediaSources fetch failed for item {}: {}", self.vendor_name, item_id, exc)
+            return []
+        items = data.get("Items") or []
+        if not items or not isinstance(items[0], dict):
+            return []
+        sources: list[tuple[str, str]] = []
+        for src in items[0].get("MediaSources") or []:
+            if isinstance(src, dict):
+                sources.append((str(src.get("Id") or ""), str(src.get("Path") or "")))
+        return sources
+
+    def media_item_versions(self, raw: dict[str, Any]) -> list[tuple[str, str]]:
+        """Yield ``(item_id, path)`` for every version of a ``/Items`` row.
+
+        Single-version items — the overwhelming majority — return the
+        top-level ``(Id, Path)`` with **no** extra network call. Multi-version
+        items (``MediaSourceCount > 1``) trigger one targeted MediaSources
+        fetch and return one ``(sourceId, sourcePath)`` per version: the
+        Emby/Jellyfin analog of the Plex #268 per-MediaPart fan-out.
+
+        The per-version ``sourceId`` becomes the MediaItem id so off-media
+        trickplay (GUID-keyed) lands in each version's own directory; the
+        ``sourcePath`` drives both the media-adjacent layout and the canonical
+        local path. Empty when the row carries no usable path.
+
+        Vendor note — this fan-out only fires on **Jellyfin**, and that's
+        correct. Jellyfin hides alternate versions behind a single merged
+        ``/Items`` row (``MediaSourceCount > 1``; alternates only via a
+        targeted ``Fields=MediaSources`` fetch), so we must fan out. Emby
+        (verified live on 4.9.5) instead returns each version as its OWN
+        ``/Items`` row in the scan view — ``list_items`` queries without a
+        ``UserId``, and only the per-user view merges versions for display —
+        so both versions are already enumerated, each row has no
+        ``MediaSourceCount`` (``count == 1`` here), and we yield one per row
+        with no extra round-trip. Emby was never affected by the bug; this is
+        a verified no-op there.
+        """
+        item_id = str(raw.get("Id") or "")
+        top_path = str(raw.get("Path") or "")
+        try:
+            count = int(raw.get("MediaSourceCount") or 1)
+        except (TypeError, ValueError):
+            count = 1
+        if count <= 1 or not item_id:
+            return [(item_id, top_path)] if top_path else []
+        versions = [(sid or item_id, spath) for sid, spath in self._fetch_media_sources(item_id) if spath]
+        # Fall back to the primary path if the sources fetch failed or was empty.
+        return versions or ([(item_id, top_path)] if top_path else [])
+
     def list_items(self, library_id: str) -> Iterator[MediaItem]:
         """Yield every video :class:`MediaItem` inside the given library.
 
@@ -523,7 +594,10 @@ class EmbyApiClient(MediaServer):
                 "ParentId": library_id,
                 "IncludeItemTypes": "Movie,Episode",
                 "Recursive": "true",
-                "Fields": "Path",
+                # MediaSourceCount is a cheap scalar — it lets us emit one
+                # MediaItem per *version* (see media_item_versions) without
+                # paying a heavy Fields=MediaSources fetch on every row.
+                "Fields": "Path,MediaSourceCount",
                 "Limit": _LIST_ITEMS_PAGE_SIZE,
                 "StartIndex": start_index,
             }
@@ -634,15 +708,18 @@ class EmbyApiClient(MediaServer):
             for raw in raw_items:
                 if not isinstance(raw, dict):
                     continue
-                path = str(raw.get("Path") or "")
-                if not path:
-                    continue
-                yield MediaItem(
-                    id=str(raw.get("Id") or ""),
-                    library_id=library_id,
-                    title=_format_emby_title(raw),
-                    remote_path=path,
-                )
+                title = _format_emby_title(raw)
+                # #268 (Emby/Jellyfin): a single library item can hold several
+                # versions (alternate/merged versions), each a distinct file.
+                # Emit one MediaItem per version so every version gets a
+                # preview; single-version items pay no extra round-trip.
+                for version_id, version_path in self.media_item_versions(raw):
+                    yield MediaItem(
+                        id=version_id,
+                        library_id=library_id,
+                        title=title,
+                        remote_path=version_path,
+                    )
 
             if len(raw_items) < _LIST_ITEMS_PAGE_SIZE:
                 return

--- a/tests/test_processing_vendors.py
+++ b/tests/test_processing_vendors.py
@@ -247,6 +247,11 @@ class TestEmbyishRecentlyAdded:
                 {"Id": "i1", "Name": "Recent", "Path": "/r/recent.mkv", "DateCreated": recent_iso},
                 {"Id": "i2", "Name": "Old", "Path": "/r/old.mkv", "DateCreated": old_iso},
             ]
+            # Single-version pass-through: real media_item_versions returns
+            # the top-level (Id, Path) for MediaSourceCount<=1 with no extra call.
+            instance.media_item_versions.side_effect = lambda raw: [
+                (str(raw.get("Id") or ""), str(raw.get("Path") or ""))
+            ]
 
             items = list(proc.scan_recently_added(cfg, lookback_hours=24))
 
@@ -254,6 +259,43 @@ class TestEmbyishRecentlyAdded:
         assert items[0].canonical_path == "/l/recent.mkv"
         assert items[0].title == "Recent"
         assert items[0].item_id_by_server == {"srv-x": "i1"}
+
+    def test_scan_recently_added_fans_out_multi_version(self):
+        """A recently-added multi-version item must yield one ProcessableItem
+        per version, each keyed by its own MediaSource id and path-mapped
+        independently — the recently-added analog of the list_items #268 fix."""
+        from datetime import datetime, timezone
+
+        proc = EmbyProcessor()
+        cfg = _config(
+            "srv-x",
+            ServerType.EMBY,
+            mappings=[{"remote_prefix": "/r", "local_prefix": "/l"}],
+        )
+        recent_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+        with patch("media_preview_generator.processing.emby.EmbyServer") as klass:
+            instance = MagicMock()
+            klass.return_value = instance
+            instance.query_items.return_value = [
+                {
+                    "Id": "item1",
+                    "Name": "Multi",
+                    "Path": "/r/Multi - 2160p.mkv",
+                    "DateCreated": recent_iso,
+                    "MediaSourceCount": 2,
+                },
+            ]
+            instance.media_item_versions.return_value = [
+                ("item1", "/r/Multi - 2160p.mkv"),
+                ("alt", "/r/Multi - 1080p.mkv"),
+            ]
+
+            items = list(proc.scan_recently_added(cfg, lookback_hours=24))
+
+        assert len(items) == 2
+        by_path = {i.canonical_path: i.item_id_by_server["srv-x"] for i in items}
+        assert by_path == {"/l/Multi - 2160p.mkv": "item1", "/l/Multi - 1080p.mkv": "alt"}
 
 
 class TestPlexProcessorRecentlyAdded:

--- a/tests/test_servers_emby.py
+++ b/tests/test_servers_emby.py
@@ -429,6 +429,54 @@ class TestListItems:
         assert second_params.get("Limit") == _LIST_ITEMS_PAGE_SIZE
         assert len(items) == _LIST_ITEMS_PAGE_SIZE + 7
 
+    def test_emby_multi_version_already_lists_each_version_separately(self, emby):
+        """Emby needs no per-version fan-out — verified live (Emby 4.9.5).
+
+        Unlike Jellyfin (which hides alternate versions behind ONE merged
+        ``/Items`` row), Emby's scan view — ``/Items`` *without* a ``UserId``,
+        exactly how ``list_items`` queries — returns each version as its OWN
+        item row (the merge into a single poster is a per-user *display* concern
+        only). So both versions are already enumerated; each row carries no
+        ``MediaSourceCount`` and ``media_item_versions`` yields exactly one
+        MediaItem per row with no extra round-trip. The #268 fan-out is a
+        no-op on Emby, and Emby was never affected by the bug.
+        """
+        resp = MagicMock()
+        resp.json.return_value = {
+            "Items": [
+                {"Id": "513286", "Type": "Movie", "Name": "Multi", "Path": "/m/Multi (2020) - 2160p.mkv"},
+                {"Id": "513287", "Type": "Movie", "Name": "Multi", "Path": "/m/Multi (2020) - 1080p.mkv"},
+            ]
+        }
+        resp.raise_for_status.return_value = None
+
+        with patch.object(EmbyServer, "_request", return_value=resp) as req:
+            items = list(emby.list_items("lib-1"))
+
+        assert len(items) == 2, "Emby lists each version as its own row; both must enumerate"
+        assert {i.remote_path for i in items} == {
+            "/m/Multi (2020) - 2160p.mkv",
+            "/m/Multi (2020) - 1080p.mkv",
+        }
+        assert {i.id for i in items} == {"513286", "513287"}
+        assert req.call_count == 1, "no per-item PlaybackInfo/MediaSources fetch — versions are already separate rows"
+
+    def test_single_version_item_does_not_fetch_media_sources(self, emby):
+        """The common case (one version) must NOT pay an extra round-trip —
+        a 100k-item library can't afford a MediaSources fetch per item."""
+        resp = MagicMock()
+        resp.json.return_value = {
+            "Items": [{"Id": "100", "Type": "Movie", "Name": "Solo", "Path": "/m/s.mkv", "MediaSourceCount": 1}]
+        }
+        resp.raise_for_status.return_value = None
+
+        with patch.object(EmbyServer, "_request", return_value=resp) as req:
+            items = list(emby.list_items("lib-1"))
+
+        assert len(items) == 1
+        assert items[0].id == "100"
+        assert req.call_count == 1, "single-version item must not trigger a MediaSources follow-up"
+
     def test_list_items_uses_extended_per_request_timeout(self, emby):
         """``list_items`` lives in the shared ``_embyish.EmbyApiClient``
         base — Emby and Jellyfin both inherit it. The extended /Items

--- a/tests/test_servers_jellyfin.py
+++ b/tests/test_servers_jellyfin.py
@@ -232,6 +232,87 @@ class TestListItems:
         assert all(isinstance(i, MediaItem) for i in items)
         assert any("S01E01" in i.title for i in items)
 
+    def test_yields_one_item_per_version_for_multi_version_item(self, jelly):
+        """Jellyfin side of the Emby/Jellyfin #268 multi-version fix: a merged
+        item must fan out to one MediaItem per MediaSource, each carrying the
+        per-version GUID (Jellyfin keys off-media trickplay on it ≥10.11.5)."""
+        list_resp = MagicMock()
+        list_resp.json.return_value = {
+            "Items": [
+                {
+                    "Id": "9895",
+                    "Type": "Movie",
+                    "Name": "Multi",
+                    "Path": "/m/Multi - 2160p.mkv",
+                    "MediaSourceCount": 2,
+                }
+            ]
+        }
+        list_resp.raise_for_status.return_value = None
+        sources_resp = MagicMock()
+        sources_resp.json.return_value = {
+            "Items": [
+                {
+                    "Id": "9895",
+                    "MediaSources": [
+                        {"Id": "9895", "Path": "/m/Multi - 2160p.mkv"},
+                        {"Id": "afc0", "Path": "/m/Multi - 1080p.mkv"},
+                    ],
+                }
+            ]
+        }
+        sources_resp.raise_for_status.return_value = None
+
+        with patch.object(JellyfinServer, "_request") as req:
+            req.side_effect = [list_resp, sources_resp]
+            items = list(jelly.list_items("lib-1"))
+
+        assert len(items) == 2
+        by_path = {i.remote_path: i.id for i in items}
+        assert by_path == {"/m/Multi - 2160p.mkv": "9895", "/m/Multi - 1080p.mkv": "afc0"}
+
+    def test_multi_version_falls_back_to_primary_when_sources_fetch_raises(self, jelly):
+        """Safety net: if the targeted MediaSources fetch errors (network blip),
+        the item must NOT be dropped — we degrade to the primary's top-level
+        (Id, Path) so the merged item still gets at least one preview."""
+        list_resp = MagicMock()
+        list_resp.json.return_value = {
+            "Items": [
+                {"Id": "9895", "Type": "Movie", "Name": "Multi", "Path": "/m/Multi - 2160p.mkv", "MediaSourceCount": 2}
+            ]
+        }
+        list_resp.raise_for_status.return_value = None
+
+        with patch.object(JellyfinServer, "_request") as req:
+            req.side_effect = [list_resp, RuntimeError("sources fetch boom")]
+            items = list(jelly.list_items("lib-1"))
+
+        assert len(items) == 1, "must degrade to the primary, not drop the whole item"
+        assert items[0].id == "9895"
+        assert items[0].remote_path == "/m/Multi - 2160p.mkv"
+
+    def test_multi_version_falls_back_to_primary_when_sources_empty(self, jelly):
+        """Same fallback when the sources fetch succeeds but yields no usable
+        paths (e.g. an item still being analysed): keep the primary, don't drop."""
+        list_resp = MagicMock()
+        list_resp.json.return_value = {
+            "Items": [
+                {"Id": "9895", "Type": "Movie", "Name": "Multi", "Path": "/m/Multi - 2160p.mkv", "MediaSourceCount": 2}
+            ]
+        }
+        list_resp.raise_for_status.return_value = None
+        empty_sources = MagicMock()
+        empty_sources.json.return_value = {"Items": [{"Id": "9895", "MediaSources": []}]}
+        empty_sources.raise_for_status.return_value = None
+
+        with patch.object(JellyfinServer, "_request") as req:
+            req.side_effect = [list_resp, empty_sources]
+            items = list(jelly.list_items("lib-1"))
+
+        assert len(items) == 1
+        assert items[0].id == "9895"
+        assert items[0].remote_path == "/m/Multi - 2160p.mkv"
+
     def test_pages_through_items_when_first_page_is_full(self, jelly):
         """A library larger than one page must be fetched in chunks.
 


### PR DESCRIPTION
Emby/Jellyfin analog of the Plex multi-version bug fixed in #269 (#268).

## Problem
**Jellyfin** merges alternate versions of a title (e.g. a 1080p + a 4K file) into **one** library item whose `/Items` row exposes only the *primary* version's `Path`. The other versions live in `MediaSources` and never surfaced during enumeration — so only one version ever got a trickplay preview.

## Fix
`list_items` (shared `_embyish` base) now emits **one MediaItem per version**:
- `MediaSourceCount` (a cheap scalar) is added to the `/Items` `Fields`. Rows with `>1` source trigger **one** targeted `Fields=MediaSources` fetch and fan out to one MediaItem per MediaSource. **Single-version items (the overwhelming majority) pay no extra round-trip.** On a fetch error/empty result we degrade to the primary path rather than drop the item.
- Each version's MediaItem id is its own **MediaSource GUID**, so off-media trickplay (GUID-keyed) lands in the right per-version directory, and Jellyfin's player — which resolves trickplay by `mediaSourceId` since **10.11.5** (PR #15757) — serves the correct tiles per version. Media-adjacent layout keys per file.
- `scan_recently_added` fans out the same way.

## Emby: unaffected (verified no-op)
Emby's scan view (`/Items` **without** a `UserId`, exactly how `list_items` queries) already returns each version as its **own** item row — the merge into one poster is a per-user *display* concern only. So both versions were always enumerated; the fan-out never fires for Emby (`MediaSourceCount` absent → 1 per row). Old code and new code both yield 2. (`UserId`-scoped queries merge to 1, but `list_items` never passes one.)

## Live verification (real containers)
| Vendor | Enumeration | Generation |
|---|---|---|
| **Jellyfin 10.11.11** (merged 1 row) | old=**1** → fixed=**2** | off-media: 2 distinct per-GUID trickplay dirs · media-adjacent: 2 per-file dirs (version-specific content) |
| **Emby 4.9.5** (each version = own row) | old=**2**, new=**2** (no regression) | 2 per-file sidecar BIFs |

## Tests
Jellyfin fan-out; **fetch-raises** and **empty-sources** fallback-to-primary; single-version no-extra-call; Emby each-version-already-separate; recently-added fan-out. Full suite green (the only failures are the known flaky xdist worker-crash pollution — all pass in isolation). Architecture Review run; the one MED (untested fallback) was fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
