### PR TITLE
fix(jellyfin): off-media instant registration + native-webhook multi-version

### DIFF
--- a/media_preview_generator/servers/_embyish.py
+++ b/media_preview_generator/servers/_embyish.py
@@ -1111,6 +1111,27 @@ class EmbyApiClient(MediaServer):
 
         return suggestions
 
+    def resolve_item_to_remote_paths(self, item_id: str) -> list[tuple[str, str]]:
+        """Return ``[(sourceId, path)]`` for EVERY version of ``item_id``.
+
+        Native-webhook analog of :meth:`media_item_versions`: a Jellyfin merged
+        item exposes its alternate versions only via ``MediaSources``, so a
+        webhook that resolves the parent id must fan out to one dispatch per
+        source. Each ``sourceId`` is the per-version GUID Jellyfin keys
+        trickplay on, so off-media previews land in the right per-version dir.
+
+        Emby items are already one-per-version (its ``/Items`` lists each
+        separately and a webhook carries the specific version's id), so this
+        returns that single source — no fan-out, matching the scan behaviour.
+        Falls back to :meth:`resolve_item_to_remote_path` if the MediaSources
+        fetch is empty.
+        """
+        versions = [(sid or item_id, path) for sid, path in self._fetch_media_sources(item_id) if path]
+        if versions:
+            return versions
+        path = self.resolve_item_to_remote_path(item_id)
+        return [(item_id, path)] if path else []
+
     def resolve_item_to_remote_path(self, item_id: str) -> str | None:
         """Return ``MediaSources[0].Path`` (or top-level ``Path``) for ``item_id``.
 

--- a/media_preview_generator/servers/base.py
+++ b/media_preview_generator/servers/base.py
@@ -355,6 +355,23 @@ class MediaServer(ABC):
         the dispatcher can canonicalise.
         """
 
+    def resolve_item_to_remote_paths(self, item_id: str) -> list[tuple[str, str]]:
+        """Return ``[(version_item_id, remote_path)]`` for EVERY version of ``item_id``.
+
+        A single library item can hold multiple *versions* (alternate/multi-
+        edition), each a distinct file. Native-webhook fan-out needs all of them
+        so every version gets a preview — the per-item analog of ``list_items``'
+        per-version emission. The default returns the lone
+        :meth:`resolve_item_to_remote_path` result (correct when an item has one
+        version, and for Emby where versions are already separate item ids);
+        :class:`PlexServer` and the Emby/Jellyfin base override to enumerate
+        every version. ``version_item_id`` is the id off-media publishers key on
+        (Jellyfin's per-version MediaSource GUID) and equals ``item_id`` when
+        there is a single version.
+        """
+        path = self.resolve_item_to_remote_path(item_id)
+        return [(item_id, path)] if path else []
+
     @property
     def path_mappings(self) -> list[dict[str, Any]]:
         """Per-server path mappings used to translate canonical paths

--- a/media_preview_generator/servers/jellyfin.py
+++ b/media_preview_generator/servers/jellyfin.py
@@ -207,11 +207,23 @@ class JellyfinServer(EmbyApiClient):
         # views agree: tiles named "<width> - 10x10/<index>.jpg"
         # match the row registered with the matching intervalMs.
         adapter_interval_ms = resolve_frame_interval(output) * 1000
+        # The plugin asks Jellyfin GetTrickplayDirectory(item, …, saveWithMedia)
+        # to locate the tiles before registering, so it MUST be told the same
+        # storage mode the JellyfinTrickplayAdapter wrote with. Omitting it
+        # let the param default to true on the plugin: an off-media publish
+        # (save_with_media=False) was then checked against the media-adjacent
+        # path, which doesn't exist → 404 → silent registration miss → off-media
+        # trickplay only appeared at the next scheduled scan, never instantly.
+        save_with_media = bool(output.get("save_with_media", True))
         try:
             resp = self._request(
                 "POST",
                 f"/MediaPreviewBridge/Trickplay/{item_id}",
-                params={"width": adapter_width, "intervalMs": adapter_interval_ms},
+                params={
+                    "width": adapter_width,
+                    "intervalMs": adapter_interval_ms,
+                    "saveWithMedia": str(save_with_media).lower(),
+                },
             )
             if resp.status_code == 204:
                 logger.info(

--- a/media_preview_generator/servers/plex.py
+++ b/media_preview_generator/servers/plex.py
@@ -1874,6 +1874,42 @@ class PlexServer(MediaServer):
                     return str(file_path)
         return None
 
+    def resolve_item_to_remote_paths(self, item_id: str) -> list[tuple[str, str]]:
+        """Return ``[(ratingKey, file)]`` for EVERY version (MediaPart) of ``item_id``.
+
+        A Plex item can hold several versions (1080p + 4K); a native webhook
+        that resolves only the parent ratingKey would otherwise preview just the
+        first. This walks every ``media[*].parts[*].file`` so the webhook fans
+        out one dispatch per version — the per-item analog of #268's
+        ``list_items`` per-``locations`` emission. All versions share the bare
+        ratingKey as their id; :class:`PlexBundleAdapter` selects each version's
+        bundle hash by matching the per-version canonical path.
+
+        (The ``/webhook`` Plex endpoint already fans out via
+        ``web/webhooks.py``; this brings the universal ``/incoming`` router to
+        parity.)
+        """
+        from ..plex_client import retry_plex_call
+
+        bare = str(item_id).rsplit("/", 1)[-1]
+        try:
+            plex = self._connect()
+            item = retry_plex_call(plex.fetchItem, int(bare))
+        except (ValueError, TypeError) as exc:
+            logger.debug("Plex item id {!r} is not numeric: {}", item_id, exc)
+            return []
+        except Exception as exc:
+            logger.debug("Plex fetchItem({}) failed: {}", item_id, exc)
+            return []
+
+        files = [
+            str(f)
+            for media in (getattr(item, "media", None) or [])
+            for part in (getattr(media, "parts", None) or [])
+            if (f := getattr(part, "file", None))
+        ]
+        return [(bare, f) for f in files]
+
     def _resolve_one_path(self, server_view_path: str) -> str | None:
         """Return the Plex ratingKey for the file at ``server_view_path``.
 

--- a/media_preview_generator/web/webhook_router.py
+++ b/media_preview_generator/web/webhook_router.py
@@ -266,27 +266,33 @@ def _canonicalize_path(remote_path: str, server_config: ServerConfig | None) -> 
     return candidates[0] if candidates else remote_path
 
 
-def _resolve_to_canonical_path(
+def _resolve_to_canonical_paths(
     *,
     kind: str,
     payload: dict[str, Any],
     registry: ServerRegistry,
     explicit_server_id: str | None = None,
-) -> tuple[str | None, dict[str, str], str]:
-    """Convert any classified payload to a canonical local file path.
+) -> tuple[list[tuple[str, dict[str, str]]], str]:
+    """Convert any classified payload to one-or-more canonical local file paths.
 
-    Returns ``(canonical_path, item_id_by_server, error_message)``.
+    Returns ``([(canonical_path, item_id_by_server), ...], error_message)``.
 
-    ``item_id_by_server`` is forwarded to :func:`process_canonical_path`
-    so per-server adapters that need a server-specific item id (Plex's
-    bundle hash; Jellyfin's manifest key) can use the dispatcher's
-    hint instead of paying for a second API roundtrip.
+    Usually one entry. A native Plex/Jellyfin webhook that carries only an
+    item id for a **multi-version** item fans out to one entry per version
+    (each with that version's path + per-version item id) so every version
+    gets a preview — the webhook analog of the #268 scan fix. Path-bearing
+    webhooks (Sonarr/Radarr, templated Jellyfin) always yield one entry.
+
+    ``item_id_by_server`` is forwarded to :func:`process_canonical_path` so
+    per-server adapters that need a server-specific item id (Plex's bundle
+    hash; Jellyfin's off-media GUID) use the dispatcher's hint instead of
+    paying for a second API roundtrip.
     """
     if kind in ("sonarr", "radarr", "path"):
         path = _path_from_path_payload(payload)
         if not path:
-            return None, {}, "payload did not carry a usable file path"
-        return path, {}, ""
+            return [], "payload did not carry a usable file path"
+        return [(path, {})], ""
 
     if kind in ("plex", "emby", "jellyfin"):
         server_id_hint = explicit_server_id or _server_id_from_payload(kind, payload)
@@ -296,39 +302,45 @@ def _resolve_to_canonical_path(
             server_id_hint=server_id_hint,
         )
         if live_server is None or server_cfg is None:
-            return None, {}, f"could not match {kind} webhook to a configured server"
+            return [], f"could not match {kind} webhook to a configured server"
 
         try:
             event: WebhookEvent | None = live_server.parse_webhook(payload, headers=dict(request.headers))
         except Exception as exc:
             logger.debug("parse_webhook raised for {}: {}", live_server.name, exc)
-            return None, {}, f"{kind} webhook parsing failed: {exc}"
+            return [], f"{kind} webhook parsing failed: {exc}"
         if event is None:
-            return None, {}, f"{kind} payload not relevant (e.g. playback event)"
+            return [], f"{kind} payload not relevant (e.g. playback event)"
 
-        # Path-bearing webhook (templated Jellyfin) — short-circuit.
+        # Path-bearing webhook (templated Jellyfin) — short-circuit, one path.
         if event.remote_path:
             canonical = _canonicalize_path(event.remote_path, server_cfg)
-            return canonical, ({live_server.id: event.item_id} if event.item_id else {}), ""
+            return [(canonical, {live_server.id: event.item_id} if event.item_id else {})], ""
 
         if not event.item_id:
-            return None, {}, f"{kind} webhook had neither item id nor path"
+            return [], f"{kind} webhook had neither item id nor path"
 
+        # Item-id webhook: expand to EVERY version (multi-version fan-out).
+        # Single-version items return one pair, so the common path is unchanged.
         try:
-            remote_path = live_server.resolve_item_to_remote_path(event.item_id)
+            versions = live_server.resolve_item_to_remote_paths(event.item_id)
         except Exception as exc:
-            return None, {}, f"resolve_item_to_remote_path failed: {exc}"
-        if not remote_path:
+            return [], f"resolve_item_to_remote_paths failed: {exc}"
+        if not versions:
             return (
-                None,
-                {},
+                [],
                 f"{kind} item {event.item_id!r} could not be resolved to a path (it may not be indexed yet)",
             )
 
-        canonical = _canonicalize_path(remote_path, server_cfg)
-        return canonical, {live_server.id: event.item_id}, ""
+        return (
+            [
+                (_canonicalize_path(remote_path, server_cfg), {live_server.id: version_id})
+                for version_id, remote_path in versions
+            ],
+            "",
+        )
 
-    return None, {}, f"unsupported webhook kind: {kind}"
+    return [], f"unsupported webhook kind: {kind}"
 
 
 @webhooks_bp.route("/incoming", methods=["POST"])
@@ -383,13 +395,13 @@ def webhook_incoming():
         )
 
     registry = _build_registry_from_settings()
-    canonical, item_id_by_server, error = _resolve_to_canonical_path(
+    resolved, error = _resolve_to_canonical_paths(
         kind=kind,
         payload=payload,
         registry=registry,
     )
 
-    if not canonical:
+    if not resolved:
         logger.info(
             "Webhook router: ignoring {} payload from {} — {}",
             kind,
@@ -399,17 +411,12 @@ def webhook_incoming():
         return jsonify({"status": "ignored", "kind": kind, "reason": error}), 202
 
     logger.info(
-        "Webhook router: routing {} payload to canonical_path={} (item hints: {})",
+        "Webhook router: routing {} payload to {} version(s): {}",
         kind,
-        canonical,
-        item_id_by_server or "{}",
+        len(resolved),
+        [c for c, _ in resolved],
     )
-    return _dispatch_canonical_path(
-        canonical,
-        item_id_by_server,
-        kind=kind,
-        regenerate=_extract_regenerate_flag(payload),
-    )
+    return _dispatch_resolved(resolved, kind=kind, regenerate=_extract_regenerate_flag(payload))
 
 
 @webhooks_bp.route("/server/<server_id>", methods=["POST"])
@@ -452,18 +459,17 @@ def webhook_per_server(server_id: str):
         )
         return jsonify({"status": "ignored", "reason": "server is disabled"}), 202
 
-    canonical, item_id_by_server, error = _resolve_to_canonical_path(
+    resolved, error = _resolve_to_canonical_paths(
         kind=kind,
         payload=payload,
         registry=registry,
         explicit_server_id=server_id,
     )
-    if not canonical:
+    if not resolved:
         return jsonify({"status": "ignored", "kind": kind, "reason": error}), 202
 
-    return _dispatch_canonical_path(
-        canonical,
-        item_id_by_server,
+    return _dispatch_resolved(
+        resolved,
         kind=kind,
         server_id_filter=server_id,
         regenerate=_extract_regenerate_flag(payload),
@@ -492,6 +498,84 @@ def _extract_regenerate_flag(payload: dict | None) -> bool:
     return str(raw).strip().lower() in ("true", "1", "yes")
 
 
+def _dispatch_resolved(
+    resolved: list[tuple[str, dict[str, str]]],
+    *,
+    kind: str,
+    server_id_filter: str | None = None,
+    regenerate: bool = False,
+):
+    """Dispatch one-or-more resolved (path, hints) pairs.
+
+    Single version (the dominant case, incl. all path-based webhooks) returns
+    the exact same one-job response as before. A multi-version item fans out to
+    one Job per version and returns an aggregate ``{"status": "queued",
+    "jobs": [...]}`` so the caller sees every version that fired.
+    """
+    if len(resolved) == 1:
+        canonical, hints = resolved[0]
+        return _dispatch_canonical_path(
+            canonical, hints, kind=kind, server_id_filter=server_id_filter, regenerate=regenerate
+        )
+
+    jobs = [
+        _create_webhook_job(canonical, hints, kind=kind, server_id_filter=server_id_filter, regenerate=regenerate)
+        for canonical, hints in resolved
+    ]
+    queued = [j for j in jobs if j.get("status") == "queued"]
+    return (
+        jsonify(
+            {
+                "status": "queued" if queued else "ignored_duplicate",
+                "kind": kind,
+                "version_count": len(resolved),
+                "jobs": jobs,
+                "message": f"{len(queued)}/{len(resolved)} version(s) queued for a multi-version item",
+            }
+        ),
+        202,
+    )
+
+
+def _create_webhook_job(
+    canonical_path: str,
+    item_id_by_server: dict[str, str],
+    *,
+    kind: str,
+    server_id_filter: str | None = None,
+    regenerate: bool = False,
+) -> dict[str, Any]:
+    """Create one vendor-webhook Job and return a result dict (no Flask response).
+
+    Shared by the single-path :func:`_dispatch_canonical_path` and the
+    multi-version :func:`_dispatch_resolved` fan-out so both build jobs the
+    same way (same dedup, same owner-sid selection).
+    """
+    owner_sid = server_id_filter or (next(iter(item_id_by_server), None) if item_id_by_server else None)
+    job_id = create_vendor_webhook_job(
+        source=kind,
+        canonical_path=canonical_path,
+        item_id_by_server=item_id_by_server,
+        server_id=owner_sid,
+        server_id_filter=server_id_filter,
+        regenerate=regenerate,
+    )
+    if job_id is None:
+        return {
+            "status": "ignored_duplicate",
+            "kind": kind,
+            "canonical_path": canonical_path,
+            "message": "Recent duplicate webhook for this file — the original Job is the authoritative one.",
+        }
+    return {
+        "status": "queued",
+        "kind": kind,
+        "canonical_path": canonical_path,
+        "job_id": job_id,
+        "message": f"Job {job_id[:8]} queued for {canonical_path}",
+    }
+
+
 def _dispatch_canonical_path(
     canonical_path: str,
     item_id_by_server: dict[str, str],
@@ -518,45 +602,16 @@ def _dispatch_canonical_path(
     webhook_prefixes via ``_log_webhook_owning_servers`` and the worker
     pool) decide ownership.
     """
-    # ``server_id_filter`` (set by /api/webhooks/server/<id>) takes precedence
-    # over any single hint when picking the server that owns this webhook.
-    # Otherwise pick the lone hint server (vendor webhooks always carry
-    # exactly one hint pair).
-    owner_sid = server_id_filter or (next(iter(item_id_by_server), None) if item_id_by_server else None)
-
-    job_id = create_vendor_webhook_job(
-        source=kind,
-        canonical_path=canonical_path,
-        item_id_by_server=item_id_by_server,
-        server_id=owner_sid,
+    # Single-path wrapper around the shared job core — preserves the exact
+    # one-job response shape every existing caller/test relies on.
+    result = _create_webhook_job(
+        canonical_path,
+        item_id_by_server,
+        kind=kind,
         server_id_filter=server_id_filter,
         regenerate=regenerate,
     )
-
-    if job_id is None:
-        # Recent-duplicate suppression — the original Job is the
-        # authoritative one. 202 keeps Plex/Emby/Jelly happy (any 2xx).
-        return (
-            jsonify(
-                {
-                    "status": "ignored_duplicate",
-                    "kind": kind,
-                    "canonical_path": canonical_path,
-                    "message": "Recent duplicate webhook for this file — the original Job is the authoritative one.",
-                }
-            ),
-            202,
-        )
-
     return (
-        jsonify(
-            {
-                "status": "queued",
-                "kind": kind,
-                "canonical_path": canonical_path,
-                "job_id": job_id,
-                "message": f"Job {job_id[:8]} queued for {canonical_path}",
-            }
-        ),
+        jsonify(result),
         202,
     )

--- a/tests/test_servers_jellyfin.py
+++ b/tests/test_servers_jellyfin.py
@@ -610,6 +610,30 @@ class TestResolveItemToRemotePath:
                 "Expected /Users/u/Items/42 — bare /Items/{id} returns 400 on Jellyfin."
             )
 
+    def test_resolve_paths_returns_one_entry_per_media_source(self, jelly):
+        """resolve_item_to_remote_paths fans a merged Jellyfin item out to one
+        (sourceId, path) per MediaSource — so a native webhook previews every
+        version, each keyed by its own per-version GUID for off-media."""
+        with patch.object(JellyfinServer, "_request") as req:
+            response = MagicMock()
+            response.json.return_value = {
+                "Items": [
+                    {
+                        "Id": "9895",
+                        "MediaSources": [
+                            {"Id": "9895", "Path": "/m/Multi - 2160p.mkv"},
+                            {"Id": "afc0", "Path": "/m/Multi - 1080p.mkv"},
+                        ],
+                    }
+                ]
+            }
+            response.raise_for_status.return_value = None
+            req.return_value = response
+
+            result = jelly.resolve_item_to_remote_paths("9895")
+
+        assert result == [("9895", "/m/Multi - 2160p.mkv"), ("afc0", "/m/Multi - 1080p.mkv")]
+
     def test_falls_back_to_plural_items_endpoint_when_no_user_id(self):
         """Without user_id (api_key auth), the universal /Items?Ids= endpoint is used."""
         config = _jelly_config(auth={"method": "api_key", "api_key": "k"})
@@ -914,6 +938,34 @@ class TestTriggerRefresh:
         assert params.get("intervalMs") == 5000, (
             f"Plugin intervalMs must equal frame_interval * 1000 (5*1000=5000); got {params!r}."
         )
+        # save_with_media unset → media-adjacent (the historical default).
+        assert params.get("saveWithMedia") == "true", (
+            f"saveWithMedia must mirror the adapter's storage mode; got {params!r}."
+        )
+
+    def test_plugin_registration_passes_save_with_media_false_for_off_media(self):
+        """Regression guard: off-media publishes MUST tell the plugin
+        ``saveWithMedia=false`` so it resolves the tiles in Jellyfin's data
+        folder. Omitting it (the bug) let the plugin default to true, check the
+        media-adjacent path that off-media never wrote, 404, and silently skip
+        instant registration — off-media trickplay then only appeared at the
+        next scheduled scan. Verified live: with this param the plugin returns
+        204 and registers immediately.
+        """
+        off_jelly = JellyfinServer(_jelly_config())
+        off_jelly._config.output = {"adapter": "jellyfin_trickplay", "save_with_media": False, "width": 320}
+
+        plugin_resp = MagicMock(status_code=204, text="")
+        refresh_resp = MagicMock()
+        refresh_resp.raise_for_status.return_value = None
+
+        with patch.object(JellyfinServer, "_request", side_effect=[plugin_resp, refresh_resp]) as req:
+            off_jelly.trigger_refresh(item_id="42", remote_path=None)
+
+        params = req.call_args_list[0].kwargs.get("params") or {}
+        assert params.get("saveWithMedia") == "false", (
+            f"off-media (save_with_media=False) must send saveWithMedia=false to the plugin; got {params!r}"
+        )
 
     def test_plugin_registration_falls_back_to_safe_defaults_when_output_missing(self):
         """Belt-and-braces — when ``server_config.output`` is empty
@@ -936,6 +988,7 @@ class TestTriggerRefresh:
         params = req.call_args_list[0].kwargs.get("params") or {}
         assert params.get("width") == 320
         assert params.get("intervalMs") == 10000
+        assert params.get("saveWithMedia") == "true"  # empty output → media-adjacent default
 
     def test_continues_to_per_item_refresh_when_plugin_not_installed(self, jelly):
         # Plugin returns 404 (not installed) — log and continue to the

--- a/tests/test_servers_plex.py
+++ b/tests/test_servers_plex.py
@@ -592,6 +592,35 @@ class TestResolveItemToRemotePath:
 
         assert plex_wrapper.resolve_item_to_remote_path("42") is None
 
+    def test_resolve_paths_returns_one_entry_per_version(self, plex_wrapper):
+        """resolve_item_to_remote_paths must yield EVERY version's file (one per
+        MediaPart) so a native webhook fans out to all versions, each tagged
+        with the bare ratingKey — the per-item analog of the #268 scan fix."""
+
+        def _part(f):
+            p = MagicMock()
+            p.file = f
+            return p
+
+        media1 = MagicMock()
+        media1.parts = [_part("/data/Foo-1080p.mkv")]
+        media2 = MagicMock()
+        media2.parts = [_part("/data/Foo-2160p.mkv")]
+        item = MagicMock()
+        item.media = [media1, media2]
+        plex = MagicMock()
+        plex.fetchItem.return_value = item
+        plex_wrapper._plex = plex
+
+        result = plex_wrapper.resolve_item_to_remote_paths("/library/metadata/42")
+        assert result == [("42", "/data/Foo-1080p.mkv"), ("42", "/data/Foo-2160p.mkv")]
+
+    def test_resolve_paths_empty_on_lookup_failure(self, plex_wrapper):
+        plex = MagicMock()
+        plex.fetchItem.side_effect = RuntimeError("boom")
+        plex_wrapper._plex = plex
+        assert plex_wrapper.resolve_item_to_remote_paths("42") == []
+
 
 class TestResolveOnePath:
     """Plex's per-server-view-path resolver hook (called by the base

--- a/tests/test_webhook_router.py
+++ b/tests/test_webhook_router.py
@@ -675,12 +675,14 @@ class TestPlexWebhook:
         from media_preview_generator.servers.plex import PlexServer
 
         self._seed_plex_server()
-        # Stub the path-resolution so we can assert on the item_id without
-        # caring how Plex would actually resolve the file.
+        # Stub the per-version path-resolution so we can assert on the item_id
+        # without caring how Plex would actually resolve the file. The router
+        # now fans out via resolve_item_to_remote_paths (plural); a single
+        # version returns one (bare-ratingKey, path) pair.
         monkeypatch.setattr(
             PlexServer,
-            "resolve_item_to_remote_path",
-            lambda self, item_id: "/data/movies/Foo.mkv",
+            "resolve_item_to_remote_paths",
+            lambda self, item_id: [(str(item_id).rsplit("/", 1)[-1], "/data/movies/Foo.mkv")],
         )
 
         plex_payload = {
@@ -715,6 +717,50 @@ class TestPlexWebhook:
             f"item_id contains '/' ({bare_id!r}) — would yield '/library/metadata//library/metadata/...' on /tree query"
         )
         assert not bare_id.startswith("/library/metadata/"), "item_id is in URL form — D31 root-cause shape"
+
+    def test_multi_version_webhook_fans_out_one_job_per_version(self, client, auth_headers, monkeypatch):
+        """A native webhook for a MULTI-version item must dispatch one Job per
+        version (the webhook analog of the #268 scan fix). Single-version
+        responses are unchanged; only multi-version returns an aggregate.
+        """
+        from media_preview_generator.servers.plex import PlexServer
+
+        self._seed_plex_server()
+        # Two versions resolved for the one ratingKey (1080p + 4K), bare id each.
+        monkeypatch.setattr(
+            PlexServer,
+            "resolve_item_to_remote_paths",
+            lambda self, item_id: [
+                ("557676", "/data/movies/Foo-1080p.mkv"),
+                ("557676", "/data/movies/Foo-2160p.mkv"),
+            ],
+        )
+        plex_payload = {"event": "library.new", "Metadata": {"ratingKey": "557676", "title": "Foo", "type": "movie"}}
+
+        with patch(
+            "media_preview_generator.web.webhook_router.create_vendor_webhook_job",
+            side_effect=["job-aaaa1111", "job-bbbb2222"],
+        ) as proc:
+            response = client.post(
+                "/api/webhooks/incoming",
+                headers=auth_headers,
+                data={"payload": json.dumps(plex_payload)},
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 202, response.get_data(as_text=True)
+        body = response.get_json()
+        assert body["status"] == "queued"
+        assert body["version_count"] == 2
+        assert len(body["jobs"]) == 2
+        # One create call per version, each with that version's distinct path.
+        assert proc.call_count == 2
+        dispatched_paths = {c.kwargs["canonical_path"] for c in proc.call_args_list}
+        assert dispatched_paths == {"/data/movies/Foo-1080p.mkv", "/data/movies/Foo-2160p.mkv"}
+        # Each version forwards the bare-ratingKey hint (load-bearing for
+        # the bundle-hash / off-media GUID selection downstream).
+        for c in proc.call_args_list:
+            assert c.kwargs["item_id_by_server"] == {"plex-1": "557676"}
 
     def test_non_library_new_event_returns_202(self, client, auth_headers):
         """Playback-state events (media.play etc.) must NOT dispatch."""
@@ -1014,6 +1060,133 @@ class TestPerServerFallback:
         assert response.status_code == 202
         proc.assert_called_once()
         assert proc.call_args.kwargs["server_id_filter"] == "plex-A"
+
+    def test_per_server_url_pins_every_version_of_a_multi_version_item(self, client, auth_headers, monkeypatch):
+        """Per-server pinning must hold for EVERY version of a multi-version
+        item — not just the first. Guards the fan-out from dropping
+        server_id_filter on the 2nd+ version (the highest-risk regression)."""
+        from media_preview_generator.servers.plex import PlexServer
+
+        _seed_servers(
+            [
+                {
+                    "id": "plex-A",
+                    "type": "plex",
+                    "name": "Plex A",
+                    "enabled": True,
+                    "url": "http://plex:32400",
+                    "auth": {"token": "tok"},
+                    "libraries": [{"id": "1", "name": "Movies", "remote_paths": ["/data/movies"], "enabled": True}],
+                },
+            ]
+        )
+        monkeypatch.setattr(
+            PlexServer,
+            "resolve_item_to_remote_paths",
+            lambda self, item_id: [
+                ("557676", "/data/movies/Foo-1080p.mkv"),
+                ("557676", "/data/movies/Foo-2160p.mkv"),
+            ],
+        )
+        plex_payload = {"event": "library.new", "Metadata": {"ratingKey": "557676", "title": "Foo", "type": "movie"}}
+
+        with patch(
+            "media_preview_generator.web.webhook_router.create_vendor_webhook_job",
+            side_effect=["job-a", "job-b"],
+        ) as proc:
+            response = client.post(
+                "/api/webhooks/server/plex-A",
+                headers=auth_headers,
+                data={"payload": json.dumps(plex_payload)},
+                content_type="multipart/form-data",
+            )
+
+        assert response.status_code == 202, response.get_data(as_text=True)
+        assert proc.call_count == 2
+        # EVERY version's job must carry the pin — not just the first.
+        assert all(c.kwargs["server_id_filter"] == "plex-A" for c in proc.call_args_list)
+
+    def test_jellyfin_item_id_webhook_fans_out_with_distinct_guids(self, client, auth_headers, monkeypatch):
+        """Router × Jellyfin multi-version: each version dispatched with its OWN
+        MediaSource GUID hint (off-media keys on it)."""
+        from media_preview_generator.servers.jellyfin import JellyfinServer
+
+        _seed_servers(
+            [
+                {
+                    "id": "jelly-1",
+                    "type": "jellyfin",
+                    "name": "Jellyfin",
+                    "enabled": True,
+                    "url": "http://jelly:8096",
+                    "auth": {"method": "api_key", "api_key": "k"},
+                    "libraries": [{"id": "1", "name": "Movies", "remote_paths": ["/data/movies"], "enabled": True}],
+                },
+            ]
+        )
+        monkeypatch.setattr(
+            JellyfinServer,
+            "resolve_item_to_remote_paths",
+            lambda self, item_id: [("9895", "/data/movies/Multi-2160p.mkv"), ("afc0", "/data/movies/Multi-1080p.mkv")],
+        )
+        payload = {"NotificationType": "ItemAdded", "ItemId": "9895", "ItemType": "Movie"}
+
+        with patch(
+            "media_preview_generator.web.webhook_router.create_vendor_webhook_job",
+            side_effect=["job-a", "job-b"],
+        ) as proc:
+            response = client.post(
+                "/api/webhooks/incoming",
+                headers={**auth_headers, "Content-Type": "application/json"},
+                data=json.dumps(payload),
+            )
+
+        assert response.status_code == 202, response.get_data(as_text=True)
+        assert proc.call_count == 2
+        hints = {frozenset(c.kwargs["item_id_by_server"].items()) for c in proc.call_args_list}
+        assert hints == {frozenset({"jelly-1": "9895"}.items()), frozenset({"jelly-1": "afc0"}.items())}
+
+    def test_emby_item_id_webhook_does_not_fan_out(self, client, auth_headers, monkeypatch):
+        """Router × Emby: versions are separate item-ids, so an item-id webhook
+        resolves to ONE source → single job, NO fan-out aggregate."""
+        from media_preview_generator.servers.emby import EmbyServer
+
+        _seed_servers(
+            [
+                {
+                    "id": "emby-1",
+                    "type": "emby",
+                    "name": "Emby",
+                    "enabled": True,
+                    "url": "http://emby:8096",
+                    "auth": {"method": "api_key", "api_key": "k"},
+                    "libraries": [{"id": "1", "name": "Movies", "remote_paths": ["/data/movies"], "enabled": True}],
+                },
+            ]
+        )
+        monkeypatch.setattr(
+            EmbyServer,
+            "resolve_item_to_remote_paths",
+            lambda self, item_id: [("513287", "/data/movies/Solo.mkv")],
+        )
+        # Emby plugin shape: top-level Event + a Server block (classifier signature).
+        payload = {"Event": "library.new", "Item": {"Id": "513287"}, "Server": {"Id": "srv"}}
+
+        with patch(
+            "media_preview_generator.web.webhook_router.create_vendor_webhook_job",
+            return_value="job-single",
+        ) as proc:
+            response = client.post(
+                "/api/webhooks/incoming",
+                headers={**auth_headers, "Content-Type": "application/json"},
+                data=json.dumps(payload),
+            )
+
+        assert response.status_code == 202, response.get_data(as_text=True)
+        body = response.get_json()
+        proc.assert_called_once()
+        assert body["status"] == "queued"
+        assert "version_count" not in body, "single-source Emby webhook must use the single-job response, not fan-out"
 
     def test_universal_url_does_not_pin_dispatch(self, client, auth_headers):
         """Sanity: the universal /api/webhooks/incoming endpoint should


### PR DESCRIPTION
Closes the two remaining multi-version / off-media edges flagged after #269/#271. Both Jellyfin-specific; **live-verified on Jellyfin 10.11.11**.

## 1. Off-media instant trickplay registration (was silently 404'ing)
The app POSTed `/MediaPreviewBridge/Trickplay/{id}` **without** `saveWithMedia`, so the plugin defaulted to `true` and asked Jellyfin for the *media-adjacent* tile dir — which an off-media publish never writes — and returned **404**. Registration then fell back to the next scheduled metadata refresh instead of appearing immediately. This affected **all** off-media items (single- and multi-version).

**Fix:** `_trigger_item_refresh` now sends `saveWithMedia` matching the adapter's mode. **App-only — no plugin release needed.**

**Live A/B (alternate version, off-media):** POST **without** the param → `404`; **with** `saveWithMedia=false` → `204 registered`. The real trigger path now logs `Registered trickplay via Media Preview Bridge plugin` for every version.

## 2. Native Jellyfin webhook → every version
A native Jellyfin webhook resolving an item id previewed only the **primary** version of a merged item (alternates live in `MediaSources`). Added `resolve_item_to_remote_paths(item_id) -> [(version_id, path)]`:
- **base:** the single `resolve_item_to_remote_path` result.
- **Jellyfin/Emby:** every `MediaSource` (each tagged with its per-version GUID for off-media); **Emby yields one** (versions are separate item ids → no fan-out, matches the scan).
- **Plex:** every `media[*].parts[*].file` by bare ratingKey — brings the universal `/incoming` router to parity with `/webhook`, which already fanned out.

`webhook_router` resolves to a **list** and fans out one Job per version. **Single-version and all Sonarr/Radarr path webhooks return the byte-identical one-job response**; multi-version returns `{"status":"queued","version_count":N,"jobs":[...]}`. `server_id_filter` is threaded into every version's Job.

**Live:** `resolve_item_to_remote_paths` returns both versions with distinct GUIDs against real Jellyfin.

## Tests
`saveWithMedia` matrix (media-adjacent / off-media / default); per-version resolvers (Plex parts, Jellyfin MediaSources, failure → `[]`); router fan-out (Plex + Jellyfin) with per-version hint assertions; **per-server URL pins every version**; Emby item-id does **not** fan out. Full suite green (the only failures are the known flaky xdist worker-crash pollution — all pass in isolation). Architecture Review run; no HIGH, the MED + 2 LOW (test-matrix gaps) closed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
