### PR TITLE
fix(jellyfin): validate the off-media config folder is actually Jellyfin's config dir

### DIFF
--- a/media_preview_generator/servers/jellyfin.py
+++ b/media_preview_generator/servers/jellyfin.py
@@ -1760,6 +1760,21 @@ class JellyfinServer(EmbyApiClient):
             if config_folder:
                 exists = os.path.isdir(config_folder)
                 writable = exists and os.access(config_folder, os.W_OK)
+                # "Right folder" check — mirrors Plex's Media/localhost probe.
+                # A real Jellyfin config dir holds the data/ folder off-media
+                # trickplay writes into (<config>/<trickplay_root>/…), plus
+                # plugins/ and config/. Pointing this at a media folder or an
+                # unrelated path is the common mistake — catch it here rather
+                # than silently writing tiles Jellyfin will never find. (It
+                # can't catch pointing one level too deep, e.g. <config>/data,
+                # since that still nests data/ + plugins/ — the markers below
+                # would still match; only a wrong/unrelated root is rejected.)
+                trickplay_root = (self.offmedia_trickplay_root or "data/trickplay").replace("\\", "/")
+                data_marker = trickplay_root.split("/", 1)[0] or "data"
+                jellyfin_markers = (data_marker, "plugins", "config", ".jellyfin-data", "system.xml")
+                looks_like_jellyfin = exists and any(
+                    os.path.exists(os.path.join(config_folder, marker)) for marker in jellyfin_markers
+                )
                 if not exists:
                     folder_ok = False
                     folder_current = "missing"
@@ -1773,6 +1788,16 @@ class JellyfinServer(EmbyApiClient):
                     folder_reason = (
                         f"{config_folder!r} is not writable by this process. "
                         "Check the Docker mount (not :ro) and PUID/PGID permissions."
+                    )
+                elif not looks_like_jellyfin:
+                    folder_ok = False
+                    folder_current = "wrong folder"
+                    folder_reason = (
+                        f"{config_folder!r} exists and is writable, but it doesn't look like "
+                        f"Jellyfin's config directory — none of '{data_marker}/', 'plugins/', 'config/' "
+                        "(or other standard Jellyfin files) are inside it. Point this at the folder "
+                        "Jellyfin uses as its config dir (the one mounted into Jellyfin as /config, "
+                        f"containing '{data_marker}/'), not a media folder or unrelated path."
                     )
                 else:
                     folder_current = "writable"
@@ -1792,7 +1817,7 @@ class JellyfinServer(EmbyApiClient):
                     "checks": [
                         {
                             "id": "config_folder_writable",
-                            "label": "Config dir mounted read-write",
+                            "label": "Config dir mounted read-write & valid",
                             "docs_anchor": "jellyfin-config-folder",
                             "tooltip": "Off-media writes trickplay into Jellyfin's config dir",
                             "explanation": (
@@ -1801,8 +1826,12 @@ class JellyfinServer(EmbyApiClient):
                                 "(<code>&lt;config&gt;/data/trickplay/…</code>) instead of next to the media. "
                                 "That means Jellyfin's config dir must be bind-mounted into THIS container "
                                 "read-write, and the 'Jellyfin config folder' setting must point at that mount.</p>"
-                                "<p>This is a read-only probe — it checks the path exists and is writable "
-                                "(<code>os.access</code>), it never writes a test file.</p>"
+                                "<p>This is a read-only probe — it checks the path (1) exists, (2) is writable "
+                                "(<code>os.access</code>), and (3) actually looks like Jellyfin's config dir "
+                                "(contains <code>data/</code>, <code>plugins/</code>, <code>config/</code>, or "
+                                "other standard Jellyfin files) so a wrong path is caught instead of silently "
+                                "writing tiles Jellyfin can't find. "
+                                "It never writes a test file.</p>"
                             ),
                             "ok": folder_ok,
                             "severity": "critical" if not folder_ok else "info",

--- a/tests/test_servers_jellyfin.py
+++ b/tests/test_servers_jellyfin.py
@@ -2478,6 +2478,7 @@ class TestOffMediaReadiness:
     def test_config_folder_writable_section_present_and_ok(self, tmp_path):
         cfg_dir = tmp_path / "jellyfin-config"
         cfg_dir.mkdir()
+        (cfg_dir / "data").mkdir()  # the data/ marker — a real Jellyfin config dir
         jelly = JellyfinServer(_jelly_config(output={"save_with_media": False, "jellyfin_config_folder": str(cfg_dir)}))
         with patch.object(
             JellyfinServer, "_request", side_effect=self._wire(config_folder=str(cfg_dir), plugin_ok=True)
@@ -2485,6 +2486,39 @@ class TestOffMediaReadiness:
             payload = jelly.previews_readiness()
         _section, check = self._find_check(payload, "config_folder_writable")
         assert check is not None
+        assert check["ok"] is True
+        assert check["current"] == "writable"
+
+    def test_config_folder_wrong_folder_is_critical(self, tmp_path):
+        """Exists + writable but NOT a Jellyfin config dir (no data/, plugins/,
+        config/) — e.g. the user pointed it at a media folder or one level too
+        deep. Must be caught as critical, mirroring Plex's Media/localhost
+        check, instead of silently writing tiles Jellyfin will never read."""
+        wrong = tmp_path / "some-media-folder"
+        wrong.mkdir()
+        (wrong / "Movie.mkv").write_bytes(b"\x00")  # looks like a media dir, not a config dir
+        jelly = JellyfinServer(_jelly_config(output={"save_with_media": False, "jellyfin_config_folder": str(wrong)}))
+        with patch.object(JellyfinServer, "_request", side_effect=self._wire(config_folder=str(wrong), plugin_ok=True)):
+            payload = jelly.previews_readiness()
+        section, check = self._find_check(payload, "config_folder_writable")
+        assert check is not None
+        assert check["ok"] is False
+        assert check["current"] == "wrong folder"
+        assert section["severity"] == "critical"
+        assert "doesn't look like" in (check["reason"] or "")
+
+    def test_config_folder_valid_when_only_plugins_marker_present(self, tmp_path):
+        """The marker set is lenient — any of data/ | plugins/ | config/ counts,
+        so an unusual-but-valid Jellyfin layout isn't falsely flagged."""
+        cfg_dir = tmp_path / "jf-cfg-plugins"
+        cfg_dir.mkdir()
+        (cfg_dir / "plugins").mkdir()  # no data/ yet, but plugins/ proves it's Jellyfin's config
+        jelly = JellyfinServer(_jelly_config(output={"save_with_media": False, "jellyfin_config_folder": str(cfg_dir)}))
+        with patch.object(
+            JellyfinServer, "_request", side_effect=self._wire(config_folder=str(cfg_dir), plugin_ok=True)
+        ):
+            payload = jelly.previews_readiness()
+        _section, check = self._find_check(payload, "config_folder_writable")
         assert check["ok"] is True
         assert check["current"] == "writable"
 


### PR DESCRIPTION
The off-media **"Jellyfin config folder"** setup-health check only validated that the path **exists** and is **writable**. As requested, it now also validates it's *actually Jellyfin's config directory* — mirroring how the **Plex** config folder is validated against its `Media/localhost` marker.

## What changed
After exists + writable pass, the check requires at least one Jellyfin marker at the folder root:
- the off-media trickplay root's first segment (default **`data`**), or **`plugins`** / **`config`** / **`.jellyfin-data`** / **`system.xml`**.

A path that exists and is writable but is a **media folder or an unrelated directory** is now flagged **critical** (`current: "wrong folder"`) with a clear fix message — instead of silently writing tiles Jellyfin will never read.

## Deliberately lenient (no false positives)
Any **one** marker passes, so a real Jellyfin config dir — official **or** linuxserver image, before or after first setup — is never wrongly flagged. It does **not** try to catch pointing one level too deep (`<config>/data` still nests `data/`+`plugins/`); the comment and the user-facing reason say so rather than over-promising (per Architecture Review).

## Tests
`ok-via-data`, `ok-via-plugins-only` (leniency), `wrong-folder → critical` (pins `current` + reason), plus the existing missing / read-only / unset rows (read-only still takes precedence over the new marker check). Architecture Review run — no HIGH; the MED + LOW (messaging over-promise) fixed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
