### PR TITLE
fix(security): bump bundled FFmpeg to 8.1.2 for CVE-2026-8461 (PixelSmash)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # =============================================================================
 # Stage 1: Builder — compile native extensions and build wheels
 # =============================================================================
-FROM linuxserver/ffmpeg:8.0.1-cli-ls64 AS builder
+FROM linuxserver/ffmpeg:8.1.2-cli-ls73 AS builder
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
@@ -53,7 +53,7 @@ RUN if [ -n "$SETUPTOOLS_SCM_PRETEND_VERSION" ]; then \
 # =============================================================================
 # Stage 2: Runtime — lean production image (no compiler toolchain)
 # =============================================================================
-FROM linuxserver/ffmpeg:8.0.1-cli-ls56
+FROM linuxserver/ffmpeg:8.1.2-cli-ls73
 
 # Build metadata (optional; set via --build-arg in CI)
 ARG GIT_BRANCH=unknown
@@ -92,16 +92,21 @@ ARG DOCKER_IMAGE_NAME=local
 # - git: For version detection when running from mounted git repository
 # - mediainfo: For media file metadata
 #
-# ffmpeg: we ship jellyfin-ffmpeg (7.1.3) as /usr/lib/jellyfin-ffmpeg/ffmpeg.
-# The base image also has an 8.0.1 build at /usr/local/bin/ffmpeg which we
+# ffmpeg: we ship jellyfin-ffmpeg (8.1.2) as /usr/lib/jellyfin-ffmpeg/ffmpeg.
+# The base image also has an 8.1.2 build at /usr/local/bin/ffmpeg which we
 # leave in place as a fallback (our code defaults to the Jellyfin binary
 # because it carries the DV RPU-aware tonemap_opencl patches upstream lacks).
+#
+# Both must stay >= 8.1.2: earlier builds are vulnerable to CVE-2026-8461
+# ("PixelSmash"), a heap OOB write in the MagicYUV decoder reachable from
+# ordinary preview generation on an untrusted library file.  jellyfin-ffmpeg7
+# is NOT an option -- it stopped at 7.1.4-3 (2026-06-06), before the fix.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
       mediainfo python3 python3-pip gosu pciutils git curl gnupg ca-certificates \
       mesa-va-drivers mesa-vulkan-drivers libva2 libva-drm2 vainfo && \
     if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-      # Jellyfin apt repo (Ubuntu Noble) for jellyfin-ffmpeg7.
+      # Jellyfin apt repo (Ubuntu Noble) for jellyfin-ffmpeg8.
       # --retry-all-errors so a flaky HTTP 403 from the repo (seen
       # intermittently in CI) is retried instead of failing the build.
       curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors --retry-connrefused \
@@ -117,7 +122,7 @@ RUN apt-get update && \
         > /etc/apt/sources.list.d/intel-graphics.list && \
       apt-get update && \
       apt-get install -y --no-install-recommends \
-        jellyfin-ffmpeg7 \
+        jellyfin-ffmpeg8 \
         intel-media-va-driver-non-free \
         i965-va-driver \
         libmfx-gen1 \

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -546,7 +546,7 @@ The tool picks the fastest working path per GPU vendor:
 | AMD Radeon | (untested locally; same flags as NVIDIA) | |
 | CPU-only fallback | ~5–10× (CPU-bound) | When no GPU is available |
 
-The image ships **jellyfin-ffmpeg 7.1.3** as its preferred FFmpeg because Jellyfin's fork carries a Dolby-Vision-aware tone-mapping patch upstream FFmpeg still lacks. Non-amd64 builds fall back to the base image's FFmpeg 8.0.1 automatically.
+The image ships **jellyfin-ffmpeg 8.1.2** as its preferred FFmpeg because Jellyfin's fork carries a Dolby-Vision-aware tone-mapping patch upstream FFmpeg still lacks. Non-amd64 builds fall back to the base image's FFmpeg 8.1.2 automatically.
 
 Profile 7/8 (with HDR10 fallback) uses the standard tone-mapping chain — no Vulkan or special handling needed.
 


### PR DESCRIPTION
Closes #280.

## The problem

The image shipped **two** FFmpeg binaries vulnerable to **CVE-2026-8461** ("PixelSmash") — a heap out-of-bounds write in libavcodec's MagicYUV decoder, CVSS 8.8, [escalated by JFrog to reliable RCE](https://jfrog.com/blog/pixelsmash-critical-ffmpeg-vulnerability-turns-media-files-into-weapons/):

| Binary | Was | Patched? |
|---|---|---|
| `/usr/lib/jellyfin-ffmpeg/ffmpeg` (default) | jellyfin-ffmpeg **7.1.4** | ❌ |
| `/usr/local/bin/ffmpeg` (non-amd64 fallback) | base image **8.0.1** | ❌ |

The demonstrated RCE was through Jellyfin's automated library-scan/thumbnail path — structurally identical to what this tool does. Unattended preview generation over untrusted library files (e.g. an auto-grabbed `.mkv`) is the exact attack surface, so this is treated as in-scope rather than theoretical.

## The fix

Bump both binaries to **≥ 8.1.2** (fixed upstream 2026-06-17):

- base image `linuxserver/ffmpeg:8.0.1-cli-ls56/ls64` → `8.1.2-cli-ls73` (both builder + runtime stages — fixes the non-amd64 fallback too)
- apt package `jellyfin-ffmpeg7` → `jellyfin-ffmpeg8` (8.1.2-2-noble)

## Why stay on jellyfin-ffmpeg (not BtbN, as the issue suggested)

We ship the fork for one reason: its **DV RPU-aware `tonemap_opencl` patch**, which upstream lacks and which is the only working Dolby Vision Profile 5 path on Intel (libplacebo→Vulkan fails with `VK_ERROR_OUT_OF_DEVICE_MEMORY` on Mesa ANV — #212). A stock/BtbN build would fix the CVE and silently break DV5 for every Intel iGPU/Arc user.

No tradeoff is needed — **jellyfin-ffmpeg8 keeps the patch.** `jellyfin-ffmpeg7` was not an option regardless: it stopped at 7.1.4-3 (2026-06-06), before the fix.

## Verification (against the built image)

- Both binaries report **8.1.2** ✅
- DV-reshape symbols in bundled `libavfilter.so.11`: **4/5** — identical to old 7.1.4, vs **0/5** in upstream 8.0.1 ✅
- `tonemap_opencl` filter present ✅
- Install path unchanged → `_resolve_ffmpeg_path()` resolves to the Jellyfin binary, no code edit needed ✅
- `docker build` succeeds ✅

## Follow-up (not in this PR)

Issue #280's secondary ask — a `FFMPEG_PATH` env override so users can hot-patch future FFmpeg CVEs without waiting on an image release — is reasonable and cheap. Tracking separately so it doesn't hold up the CVE bump. (Note: `gpu/enumeration.py:534` already logs `FFMPEG_PATH` but nothing reads it — implementing the override would make that honest.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)